### PR TITLE
Implement global search across Basecamp

### DIFF
--- a/mcp_server_cli.py
+++ b/mcp_server_cli.py
@@ -101,6 +101,17 @@ class MCPServer:
                 }
             },
             {
+                "name": "global_search",
+                "description": "Search projects, todos and campfire messages across all projects",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "query": {"type": "string", "description": "Search query"}
+                    },
+                    "required": ["query"]
+                }
+            },
+            {
                 "name": "get_comments",
                 "description": "Get comments for a Basecamp item",
                 "inputSchema": {
@@ -363,6 +374,16 @@ class MCPServer:
                     results["todos"] = search.search_todos(query)
                     results["messages"] = search.search_messages(query)
 
+                return {
+                    "status": "success",
+                    "query": query,
+                    "results": results
+                }
+
+            elif tool_name == "global_search":
+                query = arguments.get("query")
+                search = BasecampSearch(client=client)
+                results = search.global_search(query)
                 return {
                     "status": "success",
                     "query": query,


### PR DESCRIPTION
## Summary
- add `search_all_campfire_lines` and `global_search` utilities
- expose a new `global_search` tool in the CLI server
- handle the new tool in execution logic
- test the new tool and update tool list expectations

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ca8ff93cc8330a7949a410f847fcf