### PR TITLE
Add more Basecamp API endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,16 @@ Once configured, you can use these tools in Cursor:
 - `get_campfire_lines` - Get recent messages from a Basecamp campfire
 - `get_daily_check_ins` - Get project's daily check-in questions
 - `get_question_answers` - Get answers to daily check-in questions
+- `create_attachment` - Upload a file as an attachment
+- `get_events` - Get events for a recording
+- `get_webhooks` - List webhooks for a project
+- `create_webhook` - Create a webhook
+- `delete_webhook` - Delete a webhook
+- `get_documents` - List documents in a vault
+- `get_document` - Get a single document
+- `create_document` - Create a document
+- `update_document` - Update a document
+- `trash_document` - Move a document to trash
 
 ### Card Table Tools
 

--- a/basecamp_client.py
+++ b/basecamp_client.py
@@ -615,7 +615,7 @@ class BasecampClient:
         headers["Content-Length"] = str(len(data))
 
         endpoint = f"attachments.json?name={name}"
-        response = requests.post(f"{self.base_url}/{endpoint}", headers=headers, data=data)
+        response = requests.post(f"{self.base_url}/{endpoint}", auth=self.auth, headers=headers, data=data)
         if response.status_code == 201:
             return response.json()
         else:


### PR DESCRIPTION
## Summary
- support finding card tables named either `kanban_board` or `card_table`
- add API helpers for attachments, events, documents and webhooks
- expose new features through the MCP server tools
- document the new tools in the README

## Testing
- `pip install -r requirements.txt`
- `python -m pytest tests/ -v`

------
https://chatgpt.com/codex/tasks/task_e_687d45240aec8330bc24357a13962d06

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new tools for managing attachments, events, webhooks, and documents, including creating, listing, updating, and deleting these resources.
* **Documentation**
  * Updated the documentation to include the newly available tools for attachments, events, webhooks, and documents management.
* **Refactor**
  * Simplified the implementation of card table retrieval for improved clarity and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->