### PR TITLE
feat: Add get_todo tool to fetch a single todo by ID

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Overview
 
-This is a **Basecamp 3 MCP (Model Context Protocol) Server** that allows AI assistants (Cursor, Claude Desktop) to interact with Basecamp directly. It uses OAuth 2.0 for authentication and provides 63 tools for Basecamp operations.
+This is a **Basecamp 3 MCP (Model Context Protocol) Server** that allows AI assistants (Cursor, Claude Desktop) to interact with Basecamp directly. It uses OAuth 2.0 for authentication and provides 64 tools for Basecamp operations.
 
 ## Development Commands
 
@@ -42,7 +42,7 @@ python generate_claude_desktop_config.py   # For Claude Desktop
 
 | File | Purpose |
 | ------ | --------- |
-| `basecamp_fastmcp.py` | **Main MCP server** using official Anthropic FastMCP framework (63 tools) |
+| `basecamp_fastmcp.py` | **Main MCP server** using official Anthropic FastMCP framework (64 tools) |
 | `mcp_server_cli.py` | Legacy JSON-RPC server (same tools, custom implementation) |
 | `basecamp_client.py` | Basecamp 3 API client - all HTTP methods and endpoints |
 | `basecamp_oauth.py` | OAuth 2.0 client for 37signals Launchpad |
@@ -72,10 +72,10 @@ Basecamp 3 API (https://3.basecampapi.com/{account_id})
 3. Callback stores tokens in `oauth_tokens.json` (600 permissions)
 4. MCP server uses `auth_manager.ensure_authenticated()` to auto-refresh expired tokens
 
-### Tool Categories (63 total)
+### Tool Categories (64 total)
 
 - **Projects**: `get_projects`, `get_project`
-- **Todos**: `get_todolists`, `get_todos`, `create_todo`, `update_todo`, `delete_todo`, `complete_todo`, `uncomplete_todo`
+- **Todos**: `get_todolists`, `get_todos`, `get_todo`, `create_todo`, `update_todo`, `delete_todo`, `complete_todo`, `uncomplete_todo`
 - **Card Tables (Kanban)**: `get_card_table`, `get_columns`, `get_cards`, `create_card`, `move_card`, `complete_card`, etc.
 - **Card Steps**: `get_card_steps`, `create_card_step`, `complete_card_step`, etc.
 - **Comments**: `get_comments`, `create_comment`

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This project provides a **FastMCP-powered** integration for Basecamp 3, allowing Cursor to interact with Basecamp directly through the MCP protocol.
 
-✅ **Migration Complete:** Successfully migrated to official Anthropic FastMCP framework with **100% feature parity** (all 63 tools)  
+✅ **Migration Complete:** Successfully migrated to official Anthropic FastMCP framework with **100% feature parity** (all 64 tools)  
 🚀 **Ready for Production:** Full protocol compliance with MCP 2025-06-18
 
 ## Quick Setup
@@ -73,7 +73,7 @@ This server works with both **Cursor** and **Claude Desktop**. Choose your prefe
 6. **Verify in Cursor:**
    - Go to Cursor Settings → MCP
    - You should see "basecamp" with a **green checkmark**
-   - Available tools: **63 tools** for complete Basecamp control
+   - Available tools: **64 tools** for complete Basecamp control
 
 ### Test Your Setup
 
@@ -113,7 +113,7 @@ Based on the [official MCP quickstart guide](https://modelcontextprotocol.io/qui
 
 4. **Verify in Claude Desktop:**
    - Look for the "Search and tools" icon (🔍) in the chat interface
-   - You should see "basecamp" listed with all 63 tools available
+   - You should see "basecamp" listed with all 64 tools available
    - Toggle the tools on to enable Basecamp integration
 
 ### Claude Desktop Configuration
@@ -178,6 +178,7 @@ Once configured, you can use these tools in Cursor:
 - `get_project` - Get details for a specific project
 - `get_todolists` - Get todo lists for a project
 - `get_todos` - Get todos from a todo list (returns all pages; handles Basecamp pagination transparently)
+- `get_todo` - Get a single todo item by its ID
 - `search_basecamp` - Search across projects, todos, and messages
 - `get_comments` - Get comments for a Basecamp item
 - `create_comment` - Create a comment on a Basecamp item
@@ -257,7 +258,7 @@ Ask Cursor things like:
 
 The project uses the **official Anthropic FastMCP framework** for maximum reliability and compatibility:
 
-1. **FastMCP Server** (`basecamp_fastmcp.py`) - Official MCP SDK with 63 tools, compatible with both Cursor and Claude Desktop
+1. **FastMCP Server** (`basecamp_fastmcp.py`) - Official MCP SDK with 64 tools, compatible with both Cursor and Claude Desktop
 2. **OAuth App** (`oauth_app.py`) - Handles OAuth 2.0 flow with Basecamp  
 3. **Token Storage** (`token_storage.py`) - Securely stores OAuth tokens
 4. **Basecamp Client** (`basecamp_client.py`) - Basecamp API client library

--- a/basecamp_client.py
+++ b/basecamp_client.py
@@ -176,9 +176,18 @@ class BasecampClient:
 
         return all_todos
 
-    def get_todo(self, todo_id):
-        """Get a specific todo."""
-        response = self.get(f'todos/{todo_id}.json')
+    def get_todo(self, project_id, todo_id):
+        """Get a specific todo.
+
+        Args:
+            project_id (str): Project ID (bucket)
+            todo_id (str): Todo ID
+
+        Returns:
+            dict: The todo object
+        """
+        endpoint = f'buckets/{project_id}/todos/{todo_id}.json'
+        response = self.get(endpoint)
         if response.status_code == 200:
             return response.json()
         else:

--- a/basecamp_fastmcp.py
+++ b/basecamp_fastmcp.py
@@ -259,6 +259,36 @@ async def get_todos(project_id: str, todolist_id: str) -> Dict[str, Any]:
         }
 
 @mcp.tool()
+async def get_todo(project_id: str, todo_id: str) -> Dict[str, Any]:
+    """Get a single todo item by its ID.
+
+    Args:
+        project_id: Project ID
+        todo_id: The todo ID
+    """
+    client = _get_basecamp_client()
+    if not client:
+        return _get_auth_error_response()
+
+    try:
+        todo = await _run_sync(client.get_todo, project_id, todo_id)
+        return {
+            "status": "success",
+            "todo": todo
+        }
+    except Exception as e:
+        logger.error(f"Error getting todo {todo_id}: {e}")
+        if "401" in str(e) and "expired" in str(e).lower():
+            return {
+                "error": "OAuth token expired",
+                "message": "Your Basecamp OAuth token expired during the API call. Please re-authenticate by visiting http://localhost:8000 and completing the OAuth flow again."
+            }
+        return {
+            "error": "Execution error",
+            "message": str(e)
+        }
+
+@mcp.tool()
 async def create_todo(project_id: str, todolist_id: str, content: str, 
                      description: Optional[str] = None, 
                      assignee_ids: Optional[List[str]] = None,


### PR DESCRIPTION
## Summary

- Add `get_todo` MCP tool that fetches a single todo item by its ID using `GET /buckets/{project_id}/todos/{todo_id}.json`
- Fix the existing `get_todo` client method to use the correct Basecamp API endpoint with `project_id` (`buckets/{project_id}/todos/{todo_id}.json` instead of the incorrect `todos/{todo_id}.json`)

## Motivation

The Basecamp API supports fetching individual todos via `GET /buckets/{project_id}/todos/{todo_id}.json`, but the MCP server didn't expose this capability. Users were forced to fetch entire todo lists just to get details on a single todo, which is inefficient when you already know the todo ID.

## Changes

- **`basecamp_client.py`**: Updated `get_todo()` to accept `project_id` parameter and use the correct `buckets/{project_id}/todos/{todo_id}.json` endpoint (consistent with `update_todo`, `delete_todo`, `complete_todo`, etc.)
- **`basecamp_fastmcp.py`**: Added `get_todo` MCP tool following the same pattern as other todo tools (`complete_todo`, `update_todo`, etc.)
- **`README.md`** and **`CLAUDE.md`**: Updated tool count from 63 → 64 and added `get_todo` to the tool listings

## Example response

```json
{
  "status": "success",
  "todo": {
    "id": 12345678,
    "status": "active",
    "created_at": "2026-01-15T10:30:00.000Z",
    "updated_at": "2026-02-01T14:20:00.000Z",
    "title": "Update API documentation",
    "type": "Todo",
    "completed": false,
    "content": "Update API documentation",
    "description": "<div>Review and update the public API docs to reflect recent endpoint changes.</div>",
    "starts_on": null,
    "due_on": "2026-02-15",
    "comments_count": 2,
    "assignees": [
      {
        "id": 12345,
        "name": "Jane Smith"
      }
    ],
    "parent": {
      "id": 87654321,
      "title": "Sprint 12 Tasks",
      "type": "Todolist"
    },
    "bucket": {
      "id": 11223344,
      "name": "Project Alpha",
      "type": "Project"
    },
    "creator": {
      "id": 67890,
      "name": "John Doe"
    }
  }
}
```

## Test results

- [x] **Valid IDs** — Called `get_todo(project_id, todo_id)` with real IDs, returned full todo object with all expected fields (title, description, status, assignees, dates, parent todolist, bucket, creator, comments_count, etc.)
- [x] **Invalid IDs** — Called with non-existent IDs, returned clean error:
  ```json
  {"error": "Execution error", "message": "Failed to get todo: 404 - {\"status\":404,\"error\":\"Not Found\"}"}
  ```
- [x] **Expired token handling** — Uses the identical pattern as all other tools in the codebase:
  ```python
  if "401" in str(e) and "expired" in str(e).lower()
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Get Todo" tool to retrieve a single todo item by project and ID.

* **Bug Fixes**
  * Improved todo retrieval to correctly locate items within their project scope for reliable results.

* **Documentation**
  * Updated docs and README to include the new tool and reflect the tool count increase to 64.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->