### PR TITLE
fix cd path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ The script computes all paths from this repository root, so it works no matter w
 
    ```bash
    git clone <repository-url>
-   cd basecamp-mcp
+   cd Basecamp-MCP-Server
    python setup.py
    # Configure .env file with OAuth credentials
    python oauth_app.py
@@ -156,7 +156,7 @@ Based on the [official MCP quickstart guide](https://modelcontextprotocol.io/qui
 
    ```bash
    git clone <repository-url>
-   cd basecamp-mcp
+   cd Basecamp-MCP-Server
    python setup.py
    # Configure .env file with OAuth credentials
    python oauth_app.py


### PR DESCRIPTION
Noticed a small error when going through the setup steps in the README.md

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated README setup and clone instructions to use the corrected directory name ("Basecamp-MCP-Server") across occurrences, ensuring accurate local navigation guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->