### PR TITLE
Feature/configurable token dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to this project are documented here. The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [Unreleased]
+
+### Added
+
+- `BASECAMP_MCP_TOKEN_FILE` environment variable to configure the OAuth token file path. Useful for containerized deployments where the application directory is read-only or ephemeral and the token store must live on a mounted volume. When unset, the token file stays at `<project>/oauth_tokens.json` (previous default). See [README — Token Storage Location](README.md#token-storage-location).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,7 @@ python generate_claude_desktop_config.py   # For Claude Desktop
 | `basecamp_client.py` | Basecamp 3 API client - all HTTP methods and endpoints |
 | `basecamp_oauth.py` | OAuth 2.0 client for 37signals Launchpad |
 | `auth_manager.py` | Automatic token refresh before API calls |
-| `token_storage.py` | Thread-safe OAuth token persistence (`oauth_tokens.json`) |
+| `token_storage.py` | Thread-safe OAuth token persistence. Path defaults to `<project>/oauth_tokens.json`; override with `BASECAMP_MCP_TOKEN_FILE` env var |
 | `search_utils.py` | Cross-project search functionality |
 | `oauth_app.py` | Flask app for OAuth flow (browser-based login) |
 
@@ -69,7 +69,7 @@ Basecamp 3 API (https://3.basecampapi.com/{account_id})
 
 1. User runs `python oauth_app.py` and visits `http://localhost:8000`
 2. Redirected to 37signals for authorization
-3. Callback stores tokens in `oauth_tokens.json` (600 permissions)
+3. Callback stores tokens in `oauth_tokens.json` (600 permissions — location configurable via `BASECAMP_MCP_TOKEN_FILE`)
 4. MCP server uses `auth_manager.ensure_authenticated()` to auto-refresh expired tokens
 
 ### Tool Categories (75 total)

--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ ls ~/Library/Logs/Claude/mcp-server-basecamp.log
 
 - **Tools not appearing**: Verify configuration file syntax and restart Claude Desktop
 - **Connection failures**: Check that Python path and script path are absolute paths
-- **Authentication errors**: Ensure OAuth flow completed successfully (`oauth_tokens.json` exists)
+- **Authentication errors**: Ensure OAuth flow completed successfully (token file exists — see [Token Storage Location](#token-storage-location))
 
 ## Available MCP Tools
 
@@ -438,8 +438,18 @@ If you don't know your Basecamp account ID:
 ## Security Notes
 
 - Keep your `.env` file secure and never commit it to version control
-- The OAuth tokens are stored locally in `oauth_tokens.json`
+- The OAuth tokens are stored locally in `oauth_tokens.json` (600 permissions, alongside `token_storage.py`)
 - This setup is designed for local development use
+
+## Token Storage Location
+
+By default the OAuth token file lives next to `token_storage.py` (`<project>/oauth_tokens.json`). For containerized or server deployments where the project directory is read-only or ephemeral, set the `BASECAMP_MCP_TOKEN_FILE` environment variable to an absolute path:
+
+```bash
+export BASECAMP_MCP_TOKEN_FILE=/var/lib/basecamp-mcp/oauth_tokens.json
+```
+
+The path is resolved at import time; both the OAuth app and the MCP server honor the same variable, so they stay in sync without symlinks or file copies. When unset, behavior is unchanged.
 
 ## License
 

--- a/token_storage.py
+++ b/token_storage.py
@@ -14,8 +14,14 @@ import logging
 
 # Determine the directory where this script (token_storage.py) is located
 SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
-# Define TOKEN_FILE as an absolute path within that directory
-TOKEN_FILE = os.path.join(SCRIPT_DIR, 'oauth_tokens.json')
+# Token file path is configurable via BASECAMP_MCP_TOKEN_FILE env var.
+# Default: <script_dir>/oauth_tokens.json (matches original behavior).
+# Setting the env var lets deployments point the store at a mounted volume
+# (e.g. Docker/Kubernetes volume) without filesystem symlinks.
+TOKEN_FILE = os.environ.get(
+    'BASECAMP_MCP_TOKEN_FILE',
+    os.path.join(SCRIPT_DIR, 'oauth_tokens.json'),
+)
 
 # Lock for thread-safe operations
 _lock = threading.Lock()


### PR DESCRIPTION
This PR adds an ENV to configure the token file.
It's mainly written with claude code.

Let me know if you want the CHANGELOG part.

I made a [very basic setup](https://gist.github.com/schmunk42/52528bc72f45ea0ecd96788ed1df3ac6) like mentioned in #25 and this facilitates things.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configurable OAuth token storage location via the `BASECAMP_MCP_TOKEN_FILE` environment variable, enabling flexible deployments while maintaining backward compatibility.

* **Documentation**
  * Updated authentication guidance and added token storage location section in README.
  * Added changelog documenting the new configuration option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->