### PR TITLE
Fix configurable token path expansion and add regression test

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,6 +451,8 @@ export BASECAMP_MCP_TOKEN_FILE=/var/lib/basecamp-mcp/oauth_tokens.json
 
 The path is resolved at import time; both the OAuth app and the MCP server honor the same variable, so they stay in sync without symlinks or file copies. When unset, behavior is unchanged.
 
+`token_storage.py` also attempts to `chmod` the token file to `0o600` on write (best-effort; skipped on platforms that do not support it, such as Windows). If you point `BASECAMP_MCP_TOKEN_FILE` at a shared or mounted location, make sure the parent directory permissions are appropriate too, since only the token file itself is chmod'd.
+
 ## License
 
 This project is licensed under the MIT License.
@@ -464,4 +466,3 @@ This project is licensed under the MIT License.
     <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=georgeantonopoulos/Basecamp-MCP-Server&type=Date" />
   </picture>
 </a>
-

--- a/tests/test_token_storage.py
+++ b/tests/test_token_storage.py
@@ -1,0 +1,44 @@
+import importlib
+from pathlib import Path
+
+import pytest
+
+import token_storage
+
+
+@pytest.mark.parametrize(
+    "configured_path",
+    [
+        "~/tokens/oauth_tokens.json",
+        "$HOME/tokens/oauth_tokens.json",
+    ],
+)
+def test_store_token_expands_configured_token_path(configured_path, tmp_path, monkeypatch):
+    home_dir = tmp_path / "home"
+    working_dir = tmp_path / "workspace"
+    home_dir.mkdir()
+    working_dir.mkdir()
+
+    monkeypatch.chdir(working_dir)
+    monkeypatch.setenv("HOME", str(home_dir))
+    monkeypatch.setenv("BASECAMP_MCP_TOKEN_FILE", configured_path)
+
+    reloaded_token_storage = importlib.reload(token_storage)
+
+    try:
+        expected_token_file = home_dir / "tokens" / "oauth_tokens.json"
+
+        assert Path(reloaded_token_storage.TOKEN_FILE) == expected_token_file
+
+        stored = reloaded_token_storage.store_token(
+            "access-token",
+            refresh_token="refresh-token",
+            account_id="12345",
+        )
+
+        assert stored is True
+        assert expected_token_file.exists()
+        assert not (working_dir / "~").exists()
+    finally:
+        monkeypatch.delenv("BASECAMP_MCP_TOKEN_FILE", raising=False)
+        importlib.reload(token_storage)

--- a/token_storage.py
+++ b/token_storage.py
@@ -18,9 +18,11 @@ SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 # Default: <script_dir>/oauth_tokens.json (matches original behavior).
 # Setting the env var lets deployments point the store at a mounted volume
 # (e.g. Docker/Kubernetes volume) without filesystem symlinks.
-TOKEN_FILE = os.environ.get(
-    'BASECAMP_MCP_TOKEN_FILE',
-    os.path.join(SCRIPT_DIR, 'oauth_tokens.json'),
+_token_file_env = os.environ.get('BASECAMP_MCP_TOKEN_FILE')
+TOKEN_FILE = (
+    os.path.expanduser(os.path.expandvars(_token_file_env))
+    if _token_file_env
+    else os.path.join(SCRIPT_DIR, 'oauth_tokens.json')
 )
 
 # Lock for thread-safe operations


### PR DESCRIPTION
This follow-up to #26 cleans up the configurable token file path behavior.

What it changes:
- expand tilde and HOME-style values in BASECAMP_MCP_TOKEN_FILE
- add a regression test covering configured token path expansion
- document the existing 0o600 token file chmod behavior and the parent-directory permission caveat

Validation:
- venv/bin/python -m pytest tests/test_token_storage.py
- venv/bin/python -m pytest tests/test_cli_server.py tests/test_card_tables.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Token file paths now support environment variable expansion (e.g., `~` and `$HOME`).

* **Documentation**
  * Updated documentation to clarify token file permission behavior and path configuration requirements.

* **Tests**
  * Added test coverage for token path configuration expansion and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->