### PR TITLE
[codex] Add draft creation support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to this project are documented here. The format is based on 
 
 ### Added
 
+- `publish` option for `create_message` and `create_document`. The tools still
+  publish immediately by default, and callers can pass `publish: false` to omit
+  `status: "active"` and create a Basecamp draft instead.
 - `download_upload` MCP tool for retrieving the binary content of a vault `Upload` recording (PDF, image, document, …) directly through MCP. Returns the file as `ImageContent` for image MIME types and as an `EmbeddedResource` (`BlobResourceContents`) for everything else, so the MCP host can forward the blob to the model and the file is read natively (PDF tables, images, OCR) without an out-of-band fetch. Caps the payload via `max_bytes` (default 25 MB) so the MCP transport and model context are not stressed by huge files.
 - `download_attachment` MCP tool for retrieving inline comment/message attachments. Pass the `content_attachments[].download_url` returned by `get_comments` / `get_messages` and receive the file as MCP `ImageContent` (image MIME types) or `EmbeddedResource` (everything else). Required because inline attachments are `Attachment` objects, not `Upload` recordings — the `/uploads/{id}` endpoint returns 404 for their IDs. The implementation walks the 302 redirect to the pre-signed storage host manually and strips the OAuth `Authorization` header on the cross-host hop to avoid leaking the Bearer token. Honours a `max_bytes` guard (default 25 MB) via the caller-supplied `byte_size`, `Content-Length`, and a streaming cutoff.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ All notable changes to this project are documented here. The format is based on 
 - `publish` option for `create_message` and `create_document`. The tools still
   publish immediately by default, and callers can pass `publish: false` to omit
   `status: "active"` and create a Basecamp draft instead.
+- `create_draft_message` and `create_draft_document` MCP tools as explicit,
+  discoverable draft-first wrappers for agents that may miss optional flags.
 - `download_upload` MCP tool for retrieving the binary content of a vault `Upload` recording (PDF, image, document, …) directly through MCP. Returns the file as `ImageContent` for image MIME types and as an `EmbeddedResource` (`BlobResourceContents`) for everything else, so the MCP host can forward the blob to the model and the file is read natively (PDF tables, images, OCR) without an out-of-band fetch. Caps the payload via `max_bytes` (default 25 MB) so the MCP transport and model context are not stressed by huge files.
 - `download_attachment` MCP tool for retrieving inline comment/message attachments. Pass the `content_attachments[].download_url` returned by `get_comments` / `get_messages` and receive the file as MCP `ImageContent` (image MIME types) or `EmbeddedResource` (everything else). Required because inline attachments are `Attachment` objects, not `Upload` recordings — the `/uploads/{id}` endpoint returns 404 for their IDs. The implementation walks the 302 redirect to the pre-signed storage host manually and strips the OAuth `Authorization` header on the cross-host hop to avoid leaking the Bearer token. Honours a `max_bytes` guard (default 25 MB) via the caller-supplied `byte_size`, `Content-Length`, and a streaming cutoff.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Overview
 
-This is a **Basecamp 3 MCP (Model Context Protocol) Server** that allows AI assistants (Cursor, Claude Desktop) to interact with Basecamp directly. It uses OAuth 2.0 for authentication and provides 75 tools for Basecamp operations.
+This is a **Basecamp 3 MCP (Model Context Protocol) Server** that allows AI assistants (Cursor, Claude Desktop) to interact with Basecamp directly. It uses OAuth 2.0 for authentication and provides 79 tools for Basecamp operations.
 
 ## Development Commands
 
@@ -42,7 +42,7 @@ python generate_claude_desktop_config.py   # For Claude Desktop
 
 | File | Purpose |
 | ------ | --------- |
-| `basecamp_fastmcp.py` | **Main MCP server** using official Anthropic FastMCP framework (75 tools) |
+| `basecamp_fastmcp.py` | **Main MCP server** using official Anthropic FastMCP framework (79 tools) |
 | `mcp_server_cli.py` | Legacy JSON-RPC server (same tools, custom implementation) |
 | `basecamp_client.py` | Basecamp 3 API client - all HTTP methods and endpoints |
 | `basecamp_oauth.py` | OAuth 2.0 client for 37signals Launchpad |
@@ -72,7 +72,7 @@ Basecamp 3 API (https://3.basecampapi.com/{account_id})
 3. Callback stores tokens in `oauth_tokens.json` (600 permissions — location configurable via `BASECAMP_MCP_TOKEN_FILE`)
 4. MCP server uses `auth_manager.ensure_authenticated()` to auto-refresh expired tokens
 
-### Tool Categories (75 total)
+### Tool Categories (79 total)
 
 - **Projects**: `get_projects`, `get_project`
 - **Todos**: `get_todolists`, `get_todolist`, `create_todolist`, `update_todolist`, `trash_todolist`, `get_todos`, `get_todo`, `create_todo`, `update_todo`, `delete_todo`, `complete_todo`, `uncomplete_todo`, `reposition_todo`, `archive_todo`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,9 +80,9 @@ Basecamp 3 API (https://3.basecampapi.com/{account_id})
 - **Card Tables (Kanban)**: `get_card_table`, `get_columns`, `get_cards`, `create_card`, `move_card`, `complete_card`, etc.
 - **Card Steps**: `get_card_steps`, `create_card_step`, `complete_card_step`, etc.
 - **Comments**: `get_comments`, `create_comment`
-- **Messages**: `get_message_board`, `get_messages`, `get_message`, `get_message_categories`, `create_message`
+- **Messages**: `get_message_board`, `get_messages`, `get_message`, `get_message_categories`, `create_message`, `create_draft_message`
 - **Campfire (Chat)**: `get_campfire_lines`
-- **Documents**: `get_documents`, `create_document`, `update_document`, `trash_document`
+- **Documents**: `get_documents`, `create_document`, `create_draft_document`, `update_document`, `trash_document`
 - **Inbox (Email Forwards)**: `get_inbox`, `get_forwards`, `get_forward`, `get_inbox_replies`, `get_inbox_reply`, `trash_forward`
 - **Search**: `search_basecamp`, `global_search`
 - **Webhooks**: `get_webhooks`, `create_webhook`, `delete_webhook`

--- a/README.md
+++ b/README.md
@@ -14,14 +14,14 @@ The main server is [`basecamp_fastmcp.py`](basecamp_fastmcp.py). It uses the off
 - Browse Basecamp projects and project details.
 - Search across projects, todos, messages, campfire lines, comments, uploads, and schedules.
 - Read and manage todolists, todos, todo groups, and completion state.
-- Read and post message board messages, including categories.
+- Read and create message board messages, including drafts and categories.
 - Read campfire lines.
 - Read and create comments.
 - Work with card tables, columns, cards, and card steps.
 - Read inbox forwards and replies.
 - Read daily check-ins and answers.
 - Upload attachments and inspect uploads.
-- Read and manage documents.
+- Read and manage documents, including drafts.
 - List events and manage webhooks.
 - Generate local MCP configuration for Codex, Cursor, and Claude Desktop.
 
@@ -170,6 +170,10 @@ The FastMCP server exposes 77 tools.
 - `get_message`
 - `get_message_categories`
 - `create_message`
+
+Pass `publish: false` to `create_message` to create a draft message instead
+of posting it immediately.
+
 - `get_campfire_lines`
 - `get_daily_check_ins`
 - `get_question_answers`
@@ -249,6 +253,10 @@ The FastMCP server exposes 77 tools.
 - `get_documents`
 - `get_document`
 - `create_document`
+
+Pass `publish: false` to `create_document` to create a draft document instead
+of publishing it immediately.
+
 - `update_document`
 - `trash_document`
 - `get_events`

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 An MCP server for Basecamp 3. It lets MCP-capable clients such as Codex, Cursor, and Claude Desktop read and manage Basecamp projects through OAuth-authenticated Basecamp API calls.
 
-The main server is [`basecamp_fastmcp.py`](basecamp_fastmcp.py). It uses the official `mcp.server.fastmcp` Python SDK and exposes 77 tools covering projects, todos, message boards, campfires, card tables, inbox forwards, documents, uploads, comments, events, webhooks, and search.
+The main server is [`basecamp_fastmcp.py`](basecamp_fastmcp.py). It uses the official `mcp.server.fastmcp` Python SDK and exposes 79 tools covering projects, todos, message boards, campfires, card tables, inbox forwards, documents, uploads, comments, events, webhooks, and search.
 
 ## What It Can Do
 
@@ -134,7 +134,7 @@ python -m pytest tests/ -v
 
 ## Available Tools
 
-The FastMCP server exposes 77 tools.
+The FastMCP server exposes 79 tools.
 
 ### Projects And Search
 
@@ -170,9 +170,11 @@ The FastMCP server exposes 77 tools.
 - `get_message`
 - `get_message_categories`
 - `create_message`
+- `create_draft_message`
 
 Pass `publish: false` to `create_message` to create a draft message instead
-of posting it immediately.
+of posting it immediately. Agents can also call `create_draft_message` directly
+when the intended operation is specifically to create a draft.
 
 - `get_campfire_lines`
 - `get_daily_check_ins`
@@ -253,9 +255,11 @@ of posting it immediately.
 - `get_documents`
 - `get_document`
 - `create_document`
+- `create_draft_document`
 
 Pass `publish: false` to `create_document` to create a draft document instead
-of publishing it immediately.
+of publishing it immediately. Agents can also call `create_draft_document`
+directly when the intended operation is specifically to create a draft.
 
 - `update_document`
 - `trash_document`

--- a/basecamp_client.py
+++ b/basecamp_client.py
@@ -682,7 +682,7 @@ class BasecampClient:
         else:
             raise Exception(f"Failed to get message categories: {response.status_code} - {response.text}")
 
-    def create_message(self, project_id, subject, content, message_board_id=None, category_id=None):
+    def create_message(self, project_id, subject, content, message_board_id=None, category_id=None, status="active"):
         """Create a new message on a project's message board.
 
         Args:
@@ -691,6 +691,8 @@ class BasecampClient:
             content: Message body in HTML format
             message_board_id: Optional message board ID (auto-discovered if not provided)
             category_id: Optional message type/category ID
+            status: Optional message status. Set to "active" to publish immediately;
+                pass None to create a draft.
 
         Returns:
             dict: Created message details
@@ -700,7 +702,9 @@ class BasecampClient:
             message_board_id = message_board['id']
 
         endpoint = f'buckets/{project_id}/message_boards/{message_board_id}/messages.json'
-        data = {'subject': subject, 'content': content, 'status': 'active'}
+        data = {'subject': subject, 'content': content}
+        if status is not None:
+            data['status'] = status
         if category_id is not None:
             data['category_id'] = category_id
 
@@ -1362,7 +1366,9 @@ class BasecampClient:
 
     def create_document(self, project_id, vault_id, title, content, status="active"):
         """Create a document in a vault."""
-        data = {"title": title, "content": content, "status": status}
+        data = {"title": title, "content": content}
+        if status is not None:
+            data["status"] = status
         endpoint = f"buckets/{project_id}/vaults/{vault_id}/documents.json"
         response = self.post(endpoint, data)
         if response.status_code == 201:

--- a/basecamp_fastmcp.py
+++ b/basecamp_fastmcp.py
@@ -924,6 +924,29 @@ async def create_message(project_id: str, subject: str, content: str,
         }
 
 
+@mcp.tool()
+async def create_draft_message(project_id: str, subject: str, content: str,
+                               message_board_id: Optional[str] = None,
+                               category_id: Optional[str] = None) -> Dict[str, Any]:
+    """Create a draft message on a project's message board without publishing it.
+
+    Args:
+        project_id: The project ID
+        subject: Message title/subject
+        content: Message body in HTML format
+        message_board_id: Optional message board ID. If not provided, will be auto-discovered from the project.
+        category_id: Optional message type/category ID
+    """
+    return await create_message(
+        project_id,
+        subject,
+        content,
+        message_board_id=message_board_id,
+        category_id=category_id,
+        publish=False,
+    )
+
+
 # Inbox Tools (Email Forwards)
 @mcp.tool()
 async def get_inbox(project_id: str) -> Dict[str, Any]:
@@ -2252,6 +2275,25 @@ async def create_document(project_id: str, vault_id: str, title: str, content: s
             "error": "Execution error",
             "message": str(e)
         }
+
+
+@mcp.tool()
+async def create_draft_document(project_id: str, vault_id: str, title: str, content: str) -> Dict[str, Any]:
+    """Create a draft document in a vault without publishing it.
+
+    Args:
+        project_id: Project ID
+        vault_id: Vault ID
+        title: Document title
+        content: Document HTML content
+    """
+    return await create_document(
+        project_id,
+        vault_id,
+        title,
+        content,
+        publish=False,
+    )
 
 @mcp.tool()
 async def update_document(project_id: str, document_id: str, title: Optional[str] = None, content: Optional[str] = None) -> Dict[str, Any]:

--- a/basecamp_fastmcp.py
+++ b/basecamp_fastmcp.py
@@ -97,18 +97,26 @@ def _get_basecamp_client() -> Optional[BasecampClient]:
         logger.error(f"Error creating Basecamp client: {e}")
         return None
 
+def _error_response(error: str, message: str) -> Dict[str, Any]:
+    """Return a consistent MCP tool error response."""
+    return {
+        "status": "error",
+        "error": error,
+        "message": message,
+    }
+
+
 def _get_auth_error_response() -> Dict[str, Any]:
     """Return consistent auth error response."""
     if token_storage.is_token_expired():
-        return {
-            "error": "OAuth token expired",
-            "message": "Your Basecamp OAuth token has expired. Please re-authenticate by visiting http://localhost:8000 and completing the OAuth flow again."
-        }
-    else:
-        return {
-            "error": "Authentication required", 
-            "message": "Please authenticate with Basecamp first. Visit http://localhost:8000 to log in."
-        }
+        return _error_response(
+            "OAuth token expired",
+            "Your Basecamp OAuth token has expired. Please re-authenticate by visiting http://localhost:8000 and completing the OAuth flow again.",
+        )
+    return _error_response(
+        "Authentication required",
+        "Please authenticate with Basecamp first. Visit http://localhost:8000 to log in.",
+    )
 
 async def _run_sync(func, *args, **kwargs):
     """Wrapper to run synchronous functions in thread pool."""
@@ -119,14 +127,11 @@ def _handle_download_error(e: Exception, kind: str) -> Dict[str, Any]:
     """Map a BasecampClient download exception to an MCP error response."""
     logger.error(f"Error downloading {kind}: {e}")
     if "401" in str(e) and "expired" in str(e).lower():
-        return {
-            "error": "OAuth token expired",
-            "message": (
-                "Your Basecamp OAuth token expired during the API call. "
-                "Re-authenticate via this server's OAuth endpoint."
-            ),
-        }
-    return {"error": "Execution error", "message": str(e)}
+        return _error_response(
+            "OAuth token expired",
+            "Your Basecamp OAuth token expired during the API call. Re-authenticate via this server's OAuth endpoint.",
+        )
+    return _error_response("Execution error", str(e))
 
 
 def _serialize_blob_for_mcp(
@@ -914,14 +919,11 @@ async def create_message(project_id: str, subject: str, content: str,
     except Exception as e:
         logger.error(f"Error creating message: {e}")
         if "401" in str(e) and "expired" in str(e).lower():
-            return {
-                "error": "OAuth token expired",
-                "message": "Your Basecamp OAuth token expired during the API call. Please re-authenticate by visiting http://localhost:8000 and completing the OAuth flow again."
-            }
-        return {
-            "error": "Execution error",
-            "message": str(e)
-        }
+            return _error_response(
+                "OAuth token expired",
+                "Your Basecamp OAuth token expired during the API call. Please re-authenticate by visiting http://localhost:8000 and completing the OAuth flow again.",
+            )
+        return _error_response("Execution error", str(e))
 
 
 @mcp.tool()
@@ -2267,14 +2269,11 @@ async def create_document(project_id: str, vault_id: str, title: str, content: s
     except Exception as e:
         logger.error(f"Error creating document: {e}")
         if "401" in str(e) and "expired" in str(e).lower():
-            return {
-                "error": "OAuth token expired",
-                "message": "Your Basecamp OAuth token expired during the API call. Please re-authenticate by visiting http://localhost:8000 and completing the OAuth flow again."
-            }
-        return {
-            "error": "Execution error",
-            "message": str(e)
-        }
+            return _error_response(
+                "OAuth token expired",
+                "Your Basecamp OAuth token expired during the API call. Please re-authenticate by visiting http://localhost:8000 and completing the OAuth flow again.",
+            )
+        return _error_response("Execution error", str(e))
 
 
 @mcp.tool()

--- a/basecamp_fastmcp.py
+++ b/basecamp_fastmcp.py
@@ -881,7 +881,8 @@ async def get_message_categories(project_id: str) -> Dict[str, Any]:
 @mcp.tool()
 async def create_message(project_id: str, subject: str, content: str,
                          message_board_id: Optional[str] = None,
-                         category_id: Optional[str] = None) -> Dict[str, Any]:
+                         category_id: Optional[str] = None,
+                         publish: bool = True) -> Dict[str, Any]:
     """Create a new message on a project's message board.
 
     Args:
@@ -890,6 +891,7 @@ async def create_message(project_id: str, subject: str, content: str,
         content: Message body in HTML format
         message_board_id: Optional message board ID. If not provided, will be auto-discovered from the project.
         category_id: Optional message type/category ID
+        publish: When true, publish immediately. When false, create a draft.
     """
     client = _get_basecamp_client()
     if not client:
@@ -900,13 +902,14 @@ async def create_message(project_id: str, subject: str, content: str,
             lambda: client.create_message(
                 project_id, subject, content,
                 message_board_id=message_board_id,
-                category_id=category_id
+                category_id=category_id,
+                status="active" if publish else None
             )
         )
         return {
             "status": "success",
             "message": message,
-            "result": f"Message '{subject}' created successfully"
+            "result": f"Message '{subject}' {'published' if publish else 'drafted'} successfully"
         }
     except Exception as e:
         logger.error(f"Error creating message: {e}")
@@ -2209,7 +2212,8 @@ async def get_document(project_id: str, document_id: str) -> Dict[str, Any]:
         }
 
 @mcp.tool()
-async def create_document(project_id: str, vault_id: str, title: str, content: str) -> Dict[str, Any]:
+async def create_document(project_id: str, vault_id: str, title: str, content: str,
+                          publish: bool = True) -> Dict[str, Any]:
     """Create a document in a vault.
     
     Args:
@@ -2217,16 +2221,25 @@ async def create_document(project_id: str, vault_id: str, title: str, content: s
         vault_id: Vault ID
         title: Document title
         content: Document HTML content
+        publish: When true, publish immediately. When false, create a draft.
     """
     client = _get_basecamp_client()
     if not client:
         return _get_auth_error_response()
     
     try:
-        doc = await _run_sync(client.create_document, project_id, vault_id, title, content)
+        doc = await _run_sync(
+            client.create_document,
+            project_id,
+            vault_id,
+            title,
+            content,
+            "active" if publish else None,
+        )
         return {
             "status": "success",
-            "document": doc
+            "document": doc,
+            "result": f"Document '{title}' {'published' if publish else 'drafted'} successfully"
         }
     except Exception as e:
         logger.error(f"Error creating document: {e}")
@@ -2688,4 +2701,4 @@ async def reposition_todolist_group(
 if __name__ == "__main__":
     logger.info("Starting Basecamp FastMCP server")
     # Run using official MCP stdio transport
-    mcp.run(transport='stdio') 
+    mcp.run(transport='stdio')

--- a/mcp_server_cli.py
+++ b/mcp_server_cli.py
@@ -213,6 +213,22 @@ class MCPServer:
                 }
             },
             {
+                "name": "create_message",
+                "description": "Create a message on a project message board",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "project_id": {"type": "string", "description": "The project ID"},
+                        "subject": {"type": "string", "description": "Message title/subject"},
+                        "content": {"type": "string", "description": "Message content in HTML format"},
+                        "message_board_id": {"type": "string", "description": "Message board ID. If omitted, it will be auto-discovered from the project."},
+                        "category_id": {"type": "string", "description": "Optional message type/category ID"},
+                        "publish": {"type": "boolean", "description": "Publish immediately when true; create a draft when false", "default": True}
+                    },
+                    "required": ["project_id", "subject", "content"]
+                }
+            },
+            {
                 "name": "get_campfire_lines",
                 "description": "Get recent messages from a Basecamp campfire (chat room)",
                 "inputSchema": {
@@ -674,7 +690,8 @@ class MCPServer:
                         "project_id": {"type": "string", "description": "Project ID"},
                         "vault_id": {"type": "string", "description": "Vault ID"},
                         "title": {"type": "string", "description": "Document title"},
-                        "content": {"type": "string", "description": "Document HTML content"}
+                        "content": {"type": "string", "description": "Document HTML content"},
+                        "publish": {"type": "boolean", "description": "Publish immediately when true; create a draft when false", "default": True}
                     },
                     "required": ["project_id", "vault_id", "title", "content"]
                 }
@@ -1046,6 +1063,27 @@ class MCPServer:
                     "status": "success",
                     "comment": comment,
                     "message": "Comment created successfully"
+                }
+
+            elif tool_name == "create_message":
+                project_id = arguments.get("project_id")
+                subject = arguments.get("subject")
+                content = arguments.get("content")
+                message_board_id = arguments.get("message_board_id")
+                category_id = arguments.get("category_id")
+                publish = arguments.get("publish", True)
+                message = client.create_message(
+                    project_id,
+                    subject,
+                    content,
+                    message_board_id=message_board_id,
+                    category_id=category_id,
+                    status="active" if publish else None,
+                )
+                return {
+                    "status": "success",
+                    "message": message,
+                    "result": f"Message '{subject}' {'published' if publish else 'drafted'} successfully"
                 }
 
             elif tool_name == "get_campfire_lines":
@@ -1429,10 +1467,18 @@ class MCPServer:
                 vault_id = arguments.get("vault_id")
                 title = arguments.get("title")
                 content = arguments.get("content")
-                doc = client.create_document(project_id, vault_id, title, content)
+                publish = arguments.get("publish", True)
+                doc = client.create_document(
+                    project_id,
+                    vault_id,
+                    title,
+                    content,
+                    status="active" if publish else None,
+                )
                 return {
                     "status": "success",
-                    "document": doc
+                    "document": doc,
+                    "result": f"Document '{title}' {'published' if publish else 'drafted'} successfully"
                 }
 
             elif tool_name == "update_document":

--- a/mcp_server_cli.py
+++ b/mcp_server_cli.py
@@ -229,6 +229,21 @@ class MCPServer:
                 }
             },
             {
+                "name": "create_draft_message",
+                "description": "Create a draft message on a project message board without publishing it",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "project_id": {"type": "string", "description": "The project ID"},
+                        "subject": {"type": "string", "description": "Message title/subject"},
+                        "content": {"type": "string", "description": "Message content in HTML format"},
+                        "message_board_id": {"type": "string", "description": "Message board ID. If omitted, it will be auto-discovered from the project."},
+                        "category_id": {"type": "string", "description": "Optional message type/category ID"}
+                    },
+                    "required": ["project_id", "subject", "content"]
+                }
+            },
+            {
                 "name": "get_campfire_lines",
                 "description": "Get recent messages from a Basecamp campfire (chat room)",
                 "inputSchema": {
@@ -697,6 +712,20 @@ class MCPServer:
                 }
             },
             {
+                "name": "create_draft_document",
+                "description": "Create a draft document in a vault without publishing it",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "project_id": {"type": "string", "description": "Project ID"},
+                        "vault_id": {"type": "string", "description": "Vault ID"},
+                        "title": {"type": "string", "description": "Document title"},
+                        "content": {"type": "string", "description": "Document HTML content"}
+                    },
+                    "required": ["project_id", "vault_id", "title", "content"]
+                }
+            },
+            {
                 "name": "update_document",
                 "description": "Update a document",
                 "inputSchema": {
@@ -1084,6 +1113,26 @@ class MCPServer:
                     "status": "success",
                     "message": message,
                     "result": f"Message '{subject}' {'published' if publish else 'drafted'} successfully"
+                }
+
+            elif tool_name == "create_draft_message":
+                project_id = arguments.get("project_id")
+                subject = arguments.get("subject")
+                content = arguments.get("content")
+                message_board_id = arguments.get("message_board_id")
+                category_id = arguments.get("category_id")
+                message = client.create_message(
+                    project_id,
+                    subject,
+                    content,
+                    message_board_id=message_board_id,
+                    category_id=category_id,
+                    status=None,
+                )
+                return {
+                    "status": "success",
+                    "message": message,
+                    "result": f"Message '{subject}' drafted successfully"
                 }
 
             elif tool_name == "get_campfire_lines":
@@ -1479,6 +1528,24 @@ class MCPServer:
                     "status": "success",
                     "document": doc,
                     "result": f"Document '{title}' {'published' if publish else 'drafted'} successfully"
+                }
+
+            elif tool_name == "create_draft_document":
+                project_id = arguments.get("project_id")
+                vault_id = arguments.get("vault_id")
+                title = arguments.get("title")
+                content = arguments.get("content")
+                doc = client.create_document(
+                    project_id,
+                    vault_id,
+                    title,
+                    content,
+                    status=None,
+                )
+                return {
+                    "status": "success",
+                    "document": doc,
+                    "result": f"Document '{title}' drafted successfully"
                 }
 
             elif tool_name == "update_document":

--- a/mcp_server_cli.py
+++ b/mcp_server_cli.py
@@ -36,6 +36,16 @@ logging.basicConfig(
 )
 logger = logging.getLogger('mcp_cli_server')
 
+
+def _coerce_bool(value: Any, default: bool = False) -> bool:
+    """Normalize MCP boolean-ish values from clients that send strings."""
+    if value is None:
+        return default
+    if isinstance(value, str):
+        return value.strip().lower() in ("1", "true", "yes", "on")
+    return bool(value)
+
+
 class MCPServer:
     """MCP server implementing the Model Context Protocol for Cursor."""
 
@@ -958,11 +968,7 @@ class MCPServer:
                 description = arguments.get("description")
                 assignee_ids = arguments.get("assignee_ids")
                 completion_subscriber_ids = arguments.get("completion_subscriber_ids")
-                notify_arg = arguments.get("notify", False)
-                if isinstance(notify_arg, str):
-                    notify = notify_arg.strip().lower() in ("1", "true", "yes", "on")
-                else:
-                    notify = bool(notify_arg)
+                notify = _coerce_bool(arguments.get("notify", False))
                 due_on = arguments.get("due_on")
                 starts_on = arguments.get("starts_on")
                 
@@ -1100,7 +1106,7 @@ class MCPServer:
                 content = arguments.get("content")
                 message_board_id = arguments.get("message_board_id")
                 category_id = arguments.get("category_id")
-                publish = arguments.get("publish", True)
+                publish = _coerce_bool(arguments.get("publish", True), default=True)
                 message = client.create_message(
                     project_id,
                     subject,
@@ -1516,7 +1522,7 @@ class MCPServer:
                 vault_id = arguments.get("vault_id")
                 title = arguments.get("title")
                 content = arguments.get("content")
-                publish = arguments.get("publish", True)
+                publish = _coerce_bool(arguments.get("publish", True), default=True)
                 doc = client.create_document(
                     project_id,
                     vault_id,

--- a/tests/test_draft_creation.py
+++ b/tests/test_draft_creation.py
@@ -1,0 +1,148 @@
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from basecamp_client import BasecampClient
+from mcp_server_cli import MCPServer
+
+
+def _client():
+    return BasecampClient(
+        access_token="test-token",
+        account_id="12345",
+        user_agent="test-agent",
+        auth_mode="oauth",
+    )
+
+
+def _created_response(payload):
+    response = MagicMock()
+    response.status_code = 201
+    response.json.return_value = payload
+    return response
+
+
+def test_create_message_publishes_by_default():
+    client = _client()
+
+    with patch("basecamp_client.requests.post", return_value=_created_response({"id": "msg-1"})) as mock_post:
+        result = client.create_message(
+            "project-1",
+            "Kickoff",
+            "<div>Hello</div>",
+            message_board_id="board-1",
+        )
+
+    assert result == {"id": "msg-1"}
+    assert mock_post.call_args.kwargs["json"] == {
+        "subject": "Kickoff",
+        "content": "<div>Hello</div>",
+        "status": "active",
+    }
+
+
+def test_create_message_draft_omits_status():
+    client = _client()
+
+    with patch("basecamp_client.requests.post", return_value=_created_response({"id": "msg-1"})) as mock_post:
+        result = client.create_message(
+            "project-1",
+            "Kickoff",
+            "<div>Hello</div>",
+            message_board_id="board-1",
+            status=None,
+        )
+
+    assert result == {"id": "msg-1"}
+    assert mock_post.call_args.kwargs["json"] == {
+        "subject": "Kickoff",
+        "content": "<div>Hello</div>",
+    }
+
+
+def test_create_document_draft_omits_status():
+    client = _client()
+
+    with patch("basecamp_client.requests.post", return_value=_created_response({"id": "doc-1"})) as mock_post:
+        result = client.create_document(
+            "project-1",
+            "vault-1",
+            "Plan",
+            "<div>Draft</div>",
+            status=None,
+        )
+
+    assert result == {"id": "doc-1"}
+    assert mock_post.call_args.kwargs["json"] == {
+        "title": "Plan",
+        "content": "<div>Draft</div>",
+    }
+
+
+def test_cli_schema_exposes_publish_for_draft_tools():
+    tools = {tool["name"]: tool for tool in MCPServer().tools}
+
+    message_schema = tools["create_message"]["inputSchema"]["properties"]
+    document_schema = tools["create_document"]["inputSchema"]["properties"]
+
+    assert message_schema["publish"]["type"] == "boolean"
+    assert document_schema["publish"]["type"] == "boolean"
+
+
+@patch("mcp_server_cli.auth_manager.ensure_authenticated", return_value=True)
+@patch("mcp_server_cli.token_storage.get_token", return_value={"access_token": "token", "account_id": "12345"})
+def test_cli_create_message_draft_passes_status_none(mock_get_token, mock_auth):
+    server = MCPServer()
+
+    with patch.object(BasecampClient, "create_message", return_value={"id": "msg-1"}) as mock_create:
+        result = server._execute_tool(
+            "create_message",
+            {
+                "project_id": "project-1",
+                "subject": "Kickoff",
+                "content": "<div>Hello</div>",
+                "message_board_id": "board-1",
+                "publish": False,
+            },
+        )
+
+    assert result["status"] == "success"
+    assert result["result"] == "Message 'Kickoff' drafted successfully"
+    mock_create.assert_called_once_with(
+        "project-1",
+        "Kickoff",
+        "<div>Hello</div>",
+        message_board_id="board-1",
+        category_id=None,
+        status=None,
+    )
+
+
+@patch("mcp_server_cli.auth_manager.ensure_authenticated", return_value=True)
+@patch("mcp_server_cli.token_storage.get_token", return_value={"access_token": "token", "account_id": "12345"})
+def test_cli_create_document_draft_passes_status_none(mock_get_token, mock_auth):
+    server = MCPServer()
+
+    with patch.object(BasecampClient, "create_document", return_value={"id": "doc-1"}) as mock_create:
+        result = server._execute_tool(
+            "create_document",
+            {
+                "project_id": "project-1",
+                "vault_id": "vault-1",
+                "title": "Plan",
+                "content": "<div>Draft</div>",
+                "publish": False,
+            },
+        )
+
+    assert result["status"] == "success"
+    assert result["result"] == "Document 'Plan' drafted successfully"
+    mock_create.assert_called_once_with(
+        "project-1",
+        "vault-1",
+        "Plan",
+        "<div>Draft</div>",
+        status=None,
+    )

--- a/tests/test_draft_creation.py
+++ b/tests/test_draft_creation.py
@@ -89,6 +89,10 @@ def test_cli_schema_exposes_publish_for_draft_tools():
 
     assert message_schema["publish"]["type"] == "boolean"
     assert document_schema["publish"]["type"] == "boolean"
+    assert "create_draft_message" in tools
+    assert "create_draft_document" in tools
+    assert "publish" not in tools["create_draft_message"]["inputSchema"]["properties"]
+    assert "publish" not in tools["create_draft_document"]["inputSchema"]["properties"]
 
 
 @patch("mcp_server_cli.auth_manager.ensure_authenticated", return_value=True)
@@ -122,6 +126,34 @@ def test_cli_create_message_draft_passes_status_none(mock_get_token, mock_auth):
 
 @patch("mcp_server_cli.auth_manager.ensure_authenticated", return_value=True)
 @patch("mcp_server_cli.token_storage.get_token", return_value={"access_token": "token", "account_id": "12345"})
+def test_cli_create_draft_message_passes_status_none(mock_get_token, mock_auth):
+    server = MCPServer()
+
+    with patch.object(BasecampClient, "create_message", return_value={"id": "msg-1"}) as mock_create:
+        result = server._execute_tool(
+            "create_draft_message",
+            {
+                "project_id": "project-1",
+                "subject": "Kickoff",
+                "content": "<div>Hello</div>",
+                "message_board_id": "board-1",
+            },
+        )
+
+    assert result["status"] == "success"
+    assert result["result"] == "Message 'Kickoff' drafted successfully"
+    mock_create.assert_called_once_with(
+        "project-1",
+        "Kickoff",
+        "<div>Hello</div>",
+        message_board_id="board-1",
+        category_id=None,
+        status=None,
+    )
+
+
+@patch("mcp_server_cli.auth_manager.ensure_authenticated", return_value=True)
+@patch("mcp_server_cli.token_storage.get_token", return_value={"access_token": "token", "account_id": "12345"})
 def test_cli_create_document_draft_passes_status_none(mock_get_token, mock_auth):
     server = MCPServer()
 
@@ -134,6 +166,33 @@ def test_cli_create_document_draft_passes_status_none(mock_get_token, mock_auth)
                 "title": "Plan",
                 "content": "<div>Draft</div>",
                 "publish": False,
+            },
+        )
+
+    assert result["status"] == "success"
+    assert result["result"] == "Document 'Plan' drafted successfully"
+    mock_create.assert_called_once_with(
+        "project-1",
+        "vault-1",
+        "Plan",
+        "<div>Draft</div>",
+        status=None,
+    )
+
+
+@patch("mcp_server_cli.auth_manager.ensure_authenticated", return_value=True)
+@patch("mcp_server_cli.token_storage.get_token", return_value={"access_token": "token", "account_id": "12345"})
+def test_cli_create_draft_document_passes_status_none(mock_get_token, mock_auth):
+    server = MCPServer()
+
+    with patch.object(BasecampClient, "create_document", return_value={"id": "doc-1"}) as mock_create:
+        result = server._execute_tool(
+            "create_draft_document",
+            {
+                "project_id": "project-1",
+                "vault_id": "vault-1",
+                "title": "Plan",
+                "content": "<div>Draft</div>",
             },
         )
 

--- a/tests/test_draft_creation.py
+++ b/tests/test_draft_creation.py
@@ -126,6 +126,28 @@ def test_cli_create_message_draft_passes_status_none(mock_get_token, mock_auth):
 
 @patch("mcp_server_cli.auth_manager.ensure_authenticated", return_value=True)
 @patch("mcp_server_cli.token_storage.get_token", return_value={"access_token": "token", "account_id": "12345"})
+def test_cli_create_message_string_false_publish_drafts(mock_get_token, mock_auth):
+    server = MCPServer()
+
+    with patch.object(BasecampClient, "create_message", return_value={"id": "msg-1"}) as mock_create:
+        result = server._execute_tool(
+            "create_message",
+            {
+                "project_id": "project-1",
+                "subject": "Kickoff",
+                "content": "<div>Hello</div>",
+                "message_board_id": "board-1",
+                "publish": "false",
+            },
+        )
+
+    assert result["status"] == "success"
+    assert result["result"] == "Message 'Kickoff' drafted successfully"
+    assert mock_create.call_args.kwargs["status"] is None
+
+
+@patch("mcp_server_cli.auth_manager.ensure_authenticated", return_value=True)
+@patch("mcp_server_cli.token_storage.get_token", return_value={"access_token": "token", "account_id": "12345"})
 def test_cli_create_draft_message_passes_status_none(mock_get_token, mock_auth):
     server = MCPServer()
 
@@ -178,6 +200,28 @@ def test_cli_create_document_draft_passes_status_none(mock_get_token, mock_auth)
         "<div>Draft</div>",
         status=None,
     )
+
+
+@patch("mcp_server_cli.auth_manager.ensure_authenticated", return_value=True)
+@patch("mcp_server_cli.token_storage.get_token", return_value={"access_token": "token", "account_id": "12345"})
+def test_cli_create_document_string_zero_publish_drafts(mock_get_token, mock_auth):
+    server = MCPServer()
+
+    with patch.object(BasecampClient, "create_document", return_value={"id": "doc-1"}) as mock_create:
+        result = server._execute_tool(
+            "create_document",
+            {
+                "project_id": "project-1",
+                "vault_id": "vault-1",
+                "title": "Plan",
+                "content": "<div>Draft</div>",
+                "publish": "0",
+            },
+        )
+
+    assert result["status"] == "success"
+    assert result["result"] == "Document 'Plan' drafted successfully"
+    assert mock_create.call_args.kwargs["status"] is None
 
 
 @patch("mcp_server_cli.auth_manager.ensure_authenticated", return_value=True)

--- a/tests/test_fastmcp_error_response.py
+++ b/tests/test_fastmcp_error_response.py
@@ -21,6 +21,19 @@ def test_error_response_includes_status_error():
 def test_auth_error_response_includes_status_error(mock_is_expired):
     response = basecamp_fastmcp._get_auth_error_response()
 
-    assert response["status"] == "error"
-    assert response["error"] == "Authentication required"
-    assert "message" in response
+    assert response == {
+        "status": "error",
+        "error": "Authentication required",
+        "message": "Please authenticate with Basecamp first. Visit http://localhost:8000 to log in.",
+    }
+
+
+@patch("basecamp_fastmcp.token_storage.is_token_expired", return_value=True)
+def test_expired_auth_error_response_includes_status_error(mock_is_expired):
+    response = basecamp_fastmcp._get_auth_error_response()
+
+    assert response == {
+        "status": "error",
+        "error": "OAuth token expired",
+        "message": "Your Basecamp OAuth token has expired. Please re-authenticate by visiting http://localhost:8000 and completing the OAuth flow again.",
+    }

--- a/tests/test_fastmcp_error_response.py
+++ b/tests/test_fastmcp_error_response.py
@@ -1,0 +1,26 @@
+import os
+import sys
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import basecamp_fastmcp
+
+
+def test_error_response_includes_status_error():
+    response = basecamp_fastmcp._error_response("Execution error", "boom")
+
+    assert response == {
+        "status": "error",
+        "error": "Execution error",
+        "message": "boom",
+    }
+
+
+@patch("basecamp_fastmcp.token_storage.is_token_expired", return_value=False)
+def test_auth_error_response_includes_status_error(mock_is_expired):
+    response = basecamp_fastmcp._get_auth_error_response()
+
+    assert response["status"] == "error"
+    assert response["error"] == "Authentication required"
+    assert "message" in response


### PR DESCRIPTION
## Summary

Adds draft creation support for Basecamp messages and documents.

- Adds a `publish` boolean to `create_message` and `create_document`.
- Keeps current behavior by default with `publish: true`, which sends `status: "active"`.
- Allows callers to pass `publish: false`, which omits `status` so Basecamp creates a draft.
- Updates the FastMCP tools, legacy CLI schema/dispatch, README, and changelog.
- Adds focused tests for active payloads, draft payloads, CLI schema exposure, and CLI dispatch.

## Why

Issue #28 requests a way for AI agents to create reviewable drafts instead of posting messages or documents directly. Basecamp creates drafts when `status: "active"` is omitted, so the tool layer now exposes that behavior explicitly without breaking existing callers.

## Validation

- `./venv/bin/python -m pytest tests` -> `31 passed`
- `./venv/bin/python -m py_compile basecamp_fastmcp.py basecamp_client.py mcp_server_cli.py`
- `git diff --check`
- Live Basecamp validation: called `create_document` through `mcp_server_cli.py` with `publish: false` for project `37041651`, vault `7270285411`; Basecamp returned document id `9990597481` with `status: "drafted"`.

## Notes

I did not add attachment or people-tagging tests because those are separate tool capabilities. The changed behavior here is only whether the create payload includes `status: "active"` or omits it for draft creation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add draft-creation for messages and documents via a publish flag and dedicated draft tools.
  * Tools now accept common boolean forms for publish/notify inputs.

* **Refactor**
  * Standardized authentication/error responses and normalized server startup behavior.

* **Tests**
  * Added coverage for draft creation, boolean parsing, and standardized error payloads.

* **Documentation**
  * Updated changelog, README, and guides to reflect draft workflows and updated tool count (79).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->