### PR TITLE
Fix: accept 204 No Content as success for to-do/card completion

### DIFF
--- a/basecamp_client.py
+++ b/basecamp_client.py
@@ -464,7 +464,10 @@ class BasecampClient:
         """
         endpoint = f'buckets/{project_id}/todos/{todo_id}/completion.json'
         response = self.post(endpoint)
-        if response.status_code == 201:
+        # Basecamp returns 204 No Content on success (sometimes 201 with a body).
+        if response.status_code in (200, 201, 204):
+            if response.status_code == 204 or not response.text.strip():
+                return {"status": "completed", "todo_id": todo_id}
             return response.json()
         else:
             raise Exception(f"Failed to complete todo: {response.status_code} - {response.text}")
@@ -1211,7 +1214,9 @@ class BasecampClient:
     def complete_card(self, project_id, card_id):
         """Mark a card as complete."""
         response = self.post(f'buckets/{project_id}/todos/{card_id}/completion.json')
-        if response.status_code == 201:
+        if response.status_code in (200, 201, 204):
+            if response.status_code == 204 or not response.text.strip():
+                return {"status": "completed", "card_id": card_id}
             return response.json()
         else:
             raise Exception(f"Failed to complete card: {response.status_code} - {response.text}")
@@ -1277,7 +1282,9 @@ class BasecampClient:
     def complete_card_step(self, project_id, step_id):
         """Mark a card step as complete."""
         response = self.post(f'buckets/{project_id}/todos/{step_id}/completion.json')
-        if response.status_code == 201:
+        if response.status_code in (200, 201, 204):
+            if response.status_code == 204 or not response.text.strip():
+                return {"status": "completed", "step_id": step_id}
             return response.json()
         else:
             raise Exception(f"Failed to complete card step: {response.status_code} - {response.text}")

--- a/tests/test_todo_completion.py
+++ b/tests/test_todo_completion.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Tests for to-do/card completion status handling.
+
+Basecamp's completion endpoints return ``204 No Content`` on success (see
+https://github.com/basecamp/bc3-api/blob/master/sections/todos.md), so the
+completion helpers must treat 204 as success rather than raising.
+"""
+
+import os
+import sys
+import unittest
+from unittest.mock import Mock, patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+from basecamp_client import BasecampClient
+
+
+def _client():
+    return BasecampClient(
+        access_token='token', account_id='123',
+        user_agent='test-agent', auth_mode='oauth',
+    )
+
+
+def _response(status_code, text=''):
+    resp = Mock()
+    resp.status_code = status_code
+    resp.text = text
+    resp.json.return_value = {'id': 99, 'completed': True}
+    return resp
+
+
+class TestTodoCompletion(unittest.TestCase):
+    def test_complete_todo_accepts_204_no_content(self):
+        """204 with an empty body is success, not an error."""
+        client = _client()
+        with patch.object(client, 'post', return_value=_response(204, '')) as posted:
+            result = client.complete_todo('1', '2')
+        self.assertIsInstance(result, dict)
+        self.assertEqual(result.get('status'), 'completed')
+        self.assertEqual(result.get('todo_id'), '2')
+        posted.assert_called_once()
+
+    def test_complete_todo_accepts_201_with_body(self):
+        """A 201 with a JSON body still returns the parsed payload."""
+        client = _client()
+        with patch.object(client, 'post', return_value=_response(201, '{"id": 99}')):
+            result = client.complete_todo('1', '2')
+        self.assertEqual(result.get('id'), 99)
+
+    def test_complete_todo_raises_on_error_status(self):
+        client = _client()
+        with patch.object(client, 'post', return_value=_response(403, 'Forbidden')):
+            with self.assertRaises(Exception):
+                client.complete_todo('1', '2')
+
+    def test_complete_card_accepts_204(self):
+        client = _client()
+        with patch.object(client, 'post', return_value=_response(204, '')):
+            result = client.complete_card('1', '2')
+        self.assertEqual(result.get('status'), 'completed')
+
+    def test_complete_card_step_accepts_204(self):
+        client = _client()
+        with patch.object(client, 'post', return_value=_response(204, '')):
+            result = client.complete_card_step('1', '2')
+        self.assertEqual(result.get('status'), 'completed')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_todo_completion.py
+++ b/tests/test_todo_completion.py
@@ -3,7 +3,8 @@
 
 Basecamp's completion endpoints return ``204 No Content`` on success (see
 https://github.com/basecamp/bc3-api/blob/master/sections/todos.md), so the
-completion helpers must treat 204 as success rather than raising.
+completion helpers must treat 204 (and an empty body) as success rather than
+raising. They also tolerate 200/201 with a JSON body.
 """
 
 import os
@@ -17,6 +18,7 @@ from basecamp_client import BasecampClient
 
 
 def _client():
+    """Return a BasecampClient with dummy OAuth credentials for unit tests."""
     return BasecampClient(
         access_token='token', account_id='123',
         user_agent='test-agent', auth_mode='oauth',
@@ -24,6 +26,7 @@ def _client():
 
 
 def _response(status_code, text=''):
+    """Build a mock ``requests`` response with the given status and body."""
     resp = Mock()
     resp.status_code = status_code
     resp.text = text
@@ -32,6 +35,8 @@ def _response(status_code, text=''):
 
 
 class TestTodoCompletion(unittest.TestCase):
+    """Completion helpers treat 200/201/204 as success."""
+
     def test_complete_todo_accepts_204_no_content(self):
         """204 with an empty body is success, not an error."""
         client = _client()
@@ -42,6 +47,14 @@ class TestTodoCompletion(unittest.TestCase):
         self.assertEqual(result.get('todo_id'), '2')
         posted.assert_called_once()
 
+    def test_complete_todo_accepts_200_empty_body(self):
+        """200 with an empty body returns the synthesised completion dict."""
+        client = _client()
+        with patch.object(client, 'post', return_value=_response(200, '')):
+            result = client.complete_todo('1', '2')
+        self.assertEqual(result.get('status'), 'completed')
+        self.assertEqual(result.get('todo_id'), '2')
+
     def test_complete_todo_accepts_201_with_body(self):
         """A 201 with a JSON body still returns the parsed payload."""
         client = _client()
@@ -50,22 +63,43 @@ class TestTodoCompletion(unittest.TestCase):
         self.assertEqual(result.get('id'), 99)
 
     def test_complete_todo_raises_on_error_status(self):
+        """A 4xx response raises with the status code in the message."""
         client = _client()
         with patch.object(client, 'post', return_value=_response(403, 'Forbidden')):
-            with self.assertRaises(Exception):
+            with self.assertRaisesRegex(Exception, '403'):
                 client.complete_todo('1', '2')
 
     def test_complete_card_accepts_204(self):
+        """complete_card returns the completion dict (with card_id) on 204."""
         client = _client()
         with patch.object(client, 'post', return_value=_response(204, '')):
             result = client.complete_card('1', '2')
         self.assertEqual(result.get('status'), 'completed')
+        self.assertEqual(result.get('card_id'), '2')
+
+    def test_complete_card_accepts_200_empty_body(self):
+        """complete_card also accepts a 200 with an empty body."""
+        client = _client()
+        with patch.object(client, 'post', return_value=_response(200, '')):
+            result = client.complete_card('1', '2')
+        self.assertEqual(result.get('status'), 'completed')
+        self.assertEqual(result.get('card_id'), '2')
 
     def test_complete_card_step_accepts_204(self):
+        """complete_card_step returns the completion dict (with step_id) on 204."""
         client = _client()
         with patch.object(client, 'post', return_value=_response(204, '')):
             result = client.complete_card_step('1', '2')
         self.assertEqual(result.get('status'), 'completed')
+        self.assertEqual(result.get('step_id'), '2')
+
+    def test_complete_card_step_accepts_200_empty_body(self):
+        """complete_card_step also accepts a 200 with an empty body."""
+        client = _client()
+        with patch.object(client, 'post', return_value=_response(200, '')):
+            result = client.complete_card_step('1', '2')
+        self.assertEqual(result.get('status'), 'completed')
+        self.assertEqual(result.get('step_id'), '2')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Problem

`complete_todo`, `complete_card`, and `complete_card_step` only treat HTTP `201` as success. But Basecamp's completion endpoints return **204 No Content** on success, per the BC3 API docs: https://github.com/basecamp/bc3-api/blob/master/sections/todos.md ("Completing a to-do ... will return `204 No Content` if successful").

As a result, every *successful* completion raises `Exception("Failed to complete todo: 204 - ")` — callers see an error even though the item was completed.

Note the DELETE counterparts (`uncomplete_todo` / `uncomplete_card` / `uncomplete_card_step`) already correctly check for `204`; only the POST completion methods were inconsistent.

## Fix

Accept `200/201/204`. When the body is empty (204), return a small synthesised result dict instead of calling `.json()` on an empty response.

## Tests

Adds `tests/test_todo_completion.py` covering 204 No Content, 201-with-body, and error-status cases for todo / card / card-step completion. All pass under the repo venv.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Todo and card completion methods now properly handle multiple HTTP success statuses, including "No Content" responses, with consistent result formatting.

* **Tests**
  * Added test suite validating completion behavior across various server response types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->