### PR TITLE
[codex] Fix card step completion endpoint

### DIFF
--- a/basecamp_client.py
+++ b/basecamp_client.py
@@ -1281,19 +1281,23 @@ class BasecampClient:
 
     def complete_card_step(self, project_id, step_id):
         """Mark a card step as complete."""
-        response = self.post(f'buckets/{project_id}/todos/{step_id}/completion.json')
-        if response.status_code in (200, 201, 204):
-            if response.status_code == 204 or not response.text.strip():
-                return {"status": "completed", "step_id": step_id}
+        response = self.put(
+            f'buckets/{project_id}/card_tables/steps/{step_id}/completions.json',
+            {"completion": "on"},
+        )
+        if response.status_code == 200:
             return response.json()
         else:
             raise Exception(f"Failed to complete card step: {response.status_code} - {response.text}")
 
     def uncomplete_card_step(self, project_id, step_id):
         """Mark a card step as incomplete."""
-        response = self.delete(f'buckets/{project_id}/todos/{step_id}/completion.json')
-        if response.status_code == 204:
-            return True
+        response = self.put(
+            f'buckets/{project_id}/card_tables/steps/{step_id}/completions.json',
+            {"completion": "off"},
+        )
+        if response.status_code == 200:
+            return response.json()
         else:
             raise Exception(f"Failed to uncomplete card step: {response.status_code} - {response.text}")
 

--- a/tests/test_card_step_completion.py
+++ b/tests/test_card_step_completion.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Tests for Basecamp card-step completion status handling."""
+
+import os
+import sys
+import unittest
+from unittest.mock import Mock, patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+from basecamp_client import BasecampClient
+
+
+def _client():
+    """Return a BasecampClient with dummy OAuth credentials for unit tests."""
+    return BasecampClient(
+        access_token='token',
+        account_id='123',
+        user_agent='test-agent',
+        auth_mode='oauth',
+    )
+
+
+def _response(status_code, text='{"id": 2, "completed": true}', payload=None):
+    """Build a mock ``requests`` response with the given status and body."""
+    resp = Mock()
+    resp.status_code = status_code
+    resp.text = text
+    resp.json.return_value = payload or {'id': 2, 'completed': True}
+    return resp
+
+
+class TestCardStepCompletion(unittest.TestCase):
+    """Card steps use the documented card-table completions endpoint."""
+
+    def test_complete_card_step_uses_completion_on(self):
+        """Completion uses PUT with completion=on and returns the step JSON."""
+        client = _client()
+        with patch.object(client, 'put', return_value=_response(200)) as put:
+            result = client.complete_card_step('1', '2')
+
+        self.assertEqual(result.get('id'), 2)
+        self.assertTrue(result.get('completed'))
+        put.assert_called_once_with(
+            'buckets/1/card_tables/steps/2/completions.json',
+            {'completion': 'on'},
+        )
+
+    def test_uncomplete_card_step_uses_completion_off(self):
+        """Uncompletion uses PUT with completion=off and returns the step JSON."""
+        client = _client()
+        with patch.object(
+            client,
+            'put',
+            return_value=_response(200, payload={'id': 2, 'completed': False}),
+        ) as put:
+            result = client.uncomplete_card_step('1', '2')
+
+        self.assertEqual(result.get('id'), 2)
+        self.assertFalse(result.get('completed'))
+        put.assert_called_once_with(
+            'buckets/1/card_tables/steps/2/completions.json',
+            {'completion': 'off'},
+        )
+
+    def test_complete_card_step_raises_on_error_status(self):
+        """A non-200 response raises with the status code in the message."""
+        client = _client()
+        with patch.object(client, 'put', return_value=_response(404, 'Not Found')):
+            with self.assertRaisesRegex(Exception, '404'):
+                client.complete_card_step('1', '2')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_todo_completion.py
+++ b/tests/test_todo_completion.py
@@ -85,22 +85,6 @@ class TestTodoCompletion(unittest.TestCase):
         self.assertEqual(result.get('status'), 'completed')
         self.assertEqual(result.get('card_id'), '2')
 
-    def test_complete_card_step_accepts_204(self):
-        """complete_card_step returns the completion dict (with step_id) on 204."""
-        client = _client()
-        with patch.object(client, 'post', return_value=_response(204, '')):
-            result = client.complete_card_step('1', '2')
-        self.assertEqual(result.get('status'), 'completed')
-        self.assertEqual(result.get('step_id'), '2')
-
-    def test_complete_card_step_accepts_200_empty_body(self):
-        """complete_card_step also accepts a 200 with an empty body."""
-        client = _client()
-        with patch.object(client, 'post', return_value=_response(200, '')):
-            result = client.complete_card_step('1', '2')
-        self.assertEqual(result.get('status'), 'completed')
-        self.assertEqual(result.get('step_id'), '2')
-
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- Use the documented card-table step completions endpoint for card-step complete/uncomplete.
- Send completion=on/off via PUT and return the updated step JSON from Basecamp.
- Replace the old card-step assumptions in the todo completion tests with focused card-step endpoint tests.

## Why
PR #33 fixed Basecamp's 204 No Content handling for normal todo/card completion. While reviewing it, we found card steps were still being treated as normal todos. Basecamp's local BC3 docs say card steps use /card_tables/steps/{step_id}/completions.json with a completion parameter.

## Verification
- ./venv/bin/python -m pytest tests/test_todo_completion.py tests/test_card_step_completion.py -q
- ./venv/bin/python -m pytest tests -q
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated implementation for card step completion operations
  * Enhanced response handling and validation when marking card steps as complete or incomplete

* **Tests**
  * Added comprehensive test coverage for card step completion functionality
  * Improved error scenario validation and status response handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->