### PR TITLE
fix: paginate all list endpoints via shared get_all_pages helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,18 @@ All notable changes to this project are documented here. The format is based on 
 
 ### Fixed
 
+- All list helpers now follow Basecamp's `Link` header pagination via a shared
+  `get_all_pages()` helper. Previously only `get_todos`, `get_todolist_groups`,
+  `get_messages`, `get_forwards`, and `get_inbox_replies` paginated; the other
+  list endpoints (`get_projects`, `get_todolists`, `get_people`, `get_campfires`,
+  `get_campfire_lines`, `get_message_categories`, `get_schedule_entries`,
+  `get_cards`, `get_events`, `get_webhooks`, `get_documents`, `get_uploads`)
+  silently returned only the first page (15 items) — accounts with more than
+  15 projects saw a truncated project list. Same root cause as #12, applied
+  across the board.
+- `get_schedule_entries` now discovers the schedule ID from the project dock
+  (like `get_todoset`). It previously compared a `requests.Response` object
+  against `list` and therefore always returned an empty list.
 - Todo and card completion helpers now treat Basecamp's successful `204 No Content`
   responses as completed instead of raising an error.
 - Card-step completion now uses Basecamp's documented card-table step completions

--- a/basecamp_client.py
+++ b/basecamp_client.py
@@ -59,6 +59,9 @@ class BasecampClient:
     Client for interacting with Basecamp 3 API using Basic Authentication or OAuth 2.0.
     """
 
+    # Upper bound for get_all_pages(); guards against endless pagination.
+    MAX_PAGES = 1000
+
     def __init__(self, username=None, password=None, account_id=None, user_agent=None,
                  access_token=None, auth_mode="basic"):
         """
@@ -140,11 +143,20 @@ class BasecampClient:
 
         Returns:
             list: All items across all pages
+
+        Raises:
+            Exception: On a non-200 response, or if pagination exceeds
+                MAX_PAGES (guards against a malformed API response that
+                keeps advertising a next page forever).
         """
         all_items = []
         page = 1
 
         while True:
+            if page > self.MAX_PAGES:
+                raise Exception(
+                    f"Failed to get {error_label}: pagination exceeded "
+                    f"{self.MAX_PAGES} pages for endpoint {endpoint}")
             page_params = dict(params or {}, page=page)
             response = self.get(endpoint, params=page_params)
             if response.status_code != 200:

--- a/basecamp_client.py
+++ b/basecamp_client.py
@@ -125,6 +125,43 @@ class BasecampClient:
         url = f"{self.base_url}/{endpoint}"
         return requests.get(url, auth=self.auth, headers=self.headers, params=params)
 
+    def get_all_pages(self, endpoint, params=None, error_label="items"):
+        """Fetch all pages of a list endpoint, following pagination.
+
+        Basecamp paginates list endpoints (commonly 15 items per page). This
+        helper follows pagination via the `page` query parameter and the HTTP
+        `Link` header, aggregating all pages before returning the combined
+        list.
+
+        Args:
+            endpoint (str): API endpoint returning a JSON array
+            params (dict, optional): Extra query parameters
+            error_label (str): Label used in the error message on failure
+
+        Returns:
+            list: All items across all pages
+        """
+        all_items = []
+        page = 1
+
+        while True:
+            page_params = dict(params or {}, page=page)
+            response = self.get(endpoint, params=page_params)
+            if response.status_code != 200:
+                raise Exception(f"Failed to get {error_label}: {response.status_code} - {response.text}")
+
+            page_items = response.json() or []
+            all_items.extend(page_items)
+
+            # Check for next page using Link header or by empty result
+            link_header = response.headers.get("Link", "")
+            if not page_items or 'rel="next"' not in link_header:
+                break
+
+            page += 1
+
+        return all_items
+
     def post(self, endpoint, data=None):
         """Make a POST request to the Basecamp API."""
         url = f"{self.base_url}/{endpoint}"
@@ -147,12 +184,8 @@ class BasecampClient:
 
     # Project methods
     def get_projects(self):
-        """Get all projects."""
-        response = self.get('projects.json')
-        if response.status_code == 200:
-            return response.json()
-        else:
-            raise Exception(f"Failed to get projects: {response.status_code} - {response.text}")
+        """Get all projects, handling pagination."""
+        return self.get_all_pages('projects.json', error_label="projects")
 
     def get_project(self, project_id):
         """Get a specific project by ID."""
@@ -177,12 +210,10 @@ class BasecampClient:
         todoset = self.get_todoset(project_id)
         todoset_id = todoset['id']
 
-        # Then get all todolists in this todoset
-        response = self.get(f'buckets/{project_id}/todosets/{todoset_id}/todolists.json')
-        if response.status_code == 200:
-            return response.json()
-        else:
-            raise Exception(f"Failed to get todolists: {response.status_code} - {response.text}")
+        # Then get all todolists in this todoset, handling pagination
+        return self.get_all_pages(
+            f'buckets/{project_id}/todosets/{todoset_id}/todolists.json',
+            error_label="todolists")
 
     def get_todolist(self, project_id, todolist_id):
         """Get a specific todolist."""
@@ -263,29 +294,9 @@ class BasecampClient:
         the HTTP `Link` header if present, aggregating all pages before
         returning the combined list.
         """
-        endpoint = f'buckets/{project_id}/todolists/{todolist_id}/todos.json'
-
-        all_todos = []
-        page = 1
-
-        while True:
-            response = self.get(endpoint, params={"page": page})
-            if response.status_code != 200:
-                raise Exception(f"Failed to get todos: {response.status_code} - {response.text}")
-
-            page_items = response.json() or []
-            all_todos.extend(page_items)
-
-            # Check for next page using Link header or by empty result
-            link_header = response.headers.get("Link", "")
-            has_next = 'rel="next"' in link_header if link_header else False
-
-            if not page_items or not has_next:
-                break
-
-            page += 1
-
-        return all_todos
+        return self.get_all_pages(
+            f'buckets/{project_id}/todolists/{todolist_id}/todos.json',
+            error_label="todos")
 
     def get_todo(self, project_id, todo_id):
         """Get a specific todo.
@@ -501,20 +512,9 @@ class BasecampClient:
         Returns:
             list: List of group objects
         """
-        endpoint = f'buckets/{project_id}/todolists/{todolist_id}/groups.json'
-        all_groups = []
-        page = 1
-        while True:
-            response = self.get(endpoint, params={"page": page})
-            if response.status_code != 200:
-                raise Exception(f"Failed to get todolist groups: {response.status_code} - {response.text}")
-            page_items = response.json() or []
-            all_groups.extend(page_items)
-            link_header = response.headers.get("Link", "")
-            if not page_items or 'rel="next"' not in link_header:
-                break
-            page += 1
-        return all_groups
+        return self.get_all_pages(
+            f'buckets/{project_id}/todolists/{todolist_id}/groups.json',
+            error_label="todolist groups")
 
     def create_todolist_group(self, project_id, todolist_id, name, color=None):
         """Create a new group inside a todolist.
@@ -559,29 +559,20 @@ class BasecampClient:
 
     # People methods
     def get_people(self):
-        """Get all people in the account."""
-        response = self.get('people.json')
-        if response.status_code == 200:
-            return response.json()
-        else:
-            raise Exception(f"Failed to get people: {response.status_code} - {response.text}")
+        """Get all people in the account, handling pagination."""
+        return self.get_all_pages('people.json', error_label="people")
 
     # Campfire (chat) methods
     def get_campfires(self, project_id):
-        """Get the campfire for a project."""
-        response = self.get(f'buckets/{project_id}/chats.json')
-        if response.status_code == 200:
-            return response.json()
-        else:
-            raise Exception(f"Failed to get campfire: {response.status_code} - {response.text}")
+        """Get the campfires for a project, handling pagination."""
+        return self.get_all_pages(f'buckets/{project_id}/chats.json',
+                                  error_label="campfires")
 
     def get_campfire_lines(self, project_id, campfire_id):
-        """Get chat lines from a campfire."""
-        response = self.get(f'buckets/{project_id}/chats/{campfire_id}/lines.json')
-        if response.status_code == 200:
-            return response.json()
-        else:
-            raise Exception(f"Failed to get campfire lines: {response.status_code} - {response.text}")
+        """Get chat lines from a campfire, handling pagination."""
+        return self.get_all_pages(
+            f'buckets/{project_id}/chats/{campfire_id}/lines.json',
+            error_label="campfire lines")
 
     # Message board methods
     def get_message_board(self, project_id):
@@ -628,29 +619,9 @@ class BasecampClient:
             message_board = self.get_message_board(project_id)
             message_board_id = message_board['id']
 
-        endpoint = f'buckets/{project_id}/message_boards/{message_board_id}/messages.json'
-
-        all_messages = []
-        page = 1
-
-        while True:
-            response = self.get(endpoint, params={"page": page})
-            if response.status_code != 200:
-                raise Exception(f"Failed to get messages: {response.status_code} - {response.text}")
-
-            page_items = response.json() or []
-            all_messages.extend(page_items)
-
-            # Check for next page using Link header
-            link_header = response.headers.get("Link", "")
-            has_next = 'rel="next"' in link_header if link_header else False
-
-            if not page_items or not has_next:
-                break
-
-            page += 1
-
-        return all_messages
+        return self.get_all_pages(
+            f'buckets/{project_id}/message_boards/{message_board_id}/messages.json',
+            error_label="messages")
 
     def get_message(self, project_id, message_id):
         """Get a specific message.
@@ -678,12 +649,8 @@ class BasecampClient:
         Returns:
             list: Message categories with id, name, and icon
         """
-        endpoint = f'buckets/{project_id}/categories.json'
-        response = self.get(endpoint)
-        if response.status_code == 200:
-            return response.json()
-        else:
-            raise Exception(f"Failed to get message categories: {response.status_code} - {response.text}")
+        return self.get_all_pages(f'buckets/{project_id}/categories.json',
+                                  error_label="message categories")
 
     def create_message(self, project_id, subject, content, message_board_id=None, category_id=None, status="active"):
         """Create a new message on a project's message board.
@@ -757,29 +724,9 @@ class BasecampClient:
             inbox = self.get_inbox(project_id)
             inbox_id = inbox['id']
 
-        endpoint = f'buckets/{project_id}/inboxes/{inbox_id}/forwards.json'
-
-        all_forwards = []
-        page = 1
-
-        while True:
-            response = self.get(endpoint, params={"page": page})
-            if response.status_code != 200:
-                raise Exception(f"Failed to get forwards: {response.status_code} - {response.text}")
-
-            page_items = response.json() or []
-            all_forwards.extend(page_items)
-
-            # Check for next page using Link header
-            link_header = response.headers.get("Link", "")
-            has_next = 'rel="next"' in link_header if link_header else False
-
-            if not page_items or not has_next:
-                break
-
-            page += 1
-
-        return all_forwards
+        return self.get_all_pages(
+            f'buckets/{project_id}/inboxes/{inbox_id}/forwards.json',
+            error_label="forwards")
 
     def get_forward(self, project_id, forward_id):
         """Get a specific forward.
@@ -808,29 +755,9 @@ class BasecampClient:
         Returns:
             list: All replies to the forward
         """
-        endpoint = f'buckets/{project_id}/inbox_forwards/{forward_id}/replies.json'
-
-        all_replies = []
-        page = 1
-
-        while True:
-            response = self.get(endpoint, params={"page": page})
-            if response.status_code != 200:
-                raise Exception(f"Failed to get inbox replies: {response.status_code} - {response.text}")
-
-            page_items = response.json() or []
-            all_replies.extend(page_items)
-
-            # Check for next page using Link header
-            link_header = response.headers.get("Link", "")
-            has_next = 'rel="next"' in link_header if link_header else False
-
-            if not page_items or not has_next:
-                break
-
-            page += 1
-
-        return all_replies
+        return self.get_all_pages(
+            f'buckets/{project_id}/inbox_forwards/{forward_id}/replies.json',
+            error_label="inbox replies")
 
     def get_inbox_reply(self, project_id, forward_id, reply_id):
         """Get a specific inbox reply.
@@ -888,18 +815,17 @@ class BasecampClient:
         Returns:
             list: Schedule entries
         """
+        # The schedule ID is discovered from the project's dock array,
+        # following the same pattern as get_todoset().
+        project = self.get_project(project_id)
         try:
-            endpoint = f"buckets/{project_id}/schedules.json"
-            schedule = self.get(endpoint)
+            dock_item = next(_ for _ in project["dock"] if _["name"] == "schedule")
+        except (KeyError, TypeError, StopIteration):
+            return []
 
-            if isinstance(schedule, list) and len(schedule) > 0:
-                schedule_id = schedule[0]['id']
-                entries_endpoint = f"buckets/{project_id}/schedules/{schedule_id}/entries.json"
-                return self.get(entries_endpoint)
-            else:
-                return []
-        except Exception as e:
-            raise Exception(f"Failed to get schedule: {str(e)}")
+        return self.get_all_pages(
+            f"buckets/{project_id}/schedules/{dock_item['id']}/entries.json",
+            error_label="schedule entries")
 
     # Comments methods
     def get_comments(self, project_id, recording_id, page=1):
@@ -1155,12 +1081,10 @@ class BasecampClient:
 
     # Card Table Card methods
     def get_cards(self, project_id, column_id):
-        """Get all cards in a column."""
-        response = self.get(f'buckets/{project_id}/card_tables/lists/{column_id}/cards.json')
-        if response.status_code == 200:
-            return response.json()
-        else:
-            raise Exception(f"Failed to get cards: {response.status_code} - {response.text}")
+        """Get all cards in a column, handling pagination."""
+        return self.get_all_pages(
+            f'buckets/{project_id}/card_tables/lists/{column_id}/cards.json',
+            error_label="cards")
 
     def get_card(self, project_id, card_id):
         """Get a specific card."""
@@ -1319,22 +1243,15 @@ class BasecampClient:
             raise Exception(f"Failed to create attachment: {response.status_code} - {response.text}")
 
     def get_events(self, project_id, recording_id):
-        """Get events for a recording."""
-        endpoint = f"buckets/{project_id}/recordings/{recording_id}/events.json"
-        response = self.get(endpoint)
-        if response.status_code == 200:
-            return response.json()
-        else:
-            raise Exception(f"Failed to get events: {response.status_code} - {response.text}")
+        """Get events for a recording, handling pagination."""
+        return self.get_all_pages(
+            f"buckets/{project_id}/recordings/{recording_id}/events.json",
+            error_label="events")
 
     def get_webhooks(self, project_id):
-        """List webhooks for a project."""
-        endpoint = f"buckets/{project_id}/webhooks.json"
-        response = self.get(endpoint)
-        if response.status_code == 200:
-            return response.json()
-        else:
-            raise Exception(f"Failed to get webhooks: {response.status_code} - {response.text}")
+        """List webhooks for a project, handling pagination."""
+        return self.get_all_pages(f"buckets/{project_id}/webhooks.json",
+                                  error_label="webhooks")
 
     def create_webhook(self, project_id, payload_url, types=None):
         """Create a webhook for a project."""
@@ -1358,13 +1275,10 @@ class BasecampClient:
             raise Exception(f"Failed to delete webhook: {response.status_code} - {response.text}")
 
     def get_documents(self, project_id, vault_id):
-        """List documents in a vault."""
-        endpoint = f"buckets/{project_id}/vaults/{vault_id}/documents.json"
-        response = self.get(endpoint)
-        if response.status_code == 200:
-            return response.json()
-        else:
-            raise Exception(f"Failed to get documents: {response.status_code} - {response.text}")
+        """List documents in a vault, handling pagination."""
+        return self.get_all_pages(
+            f"buckets/{project_id}/vaults/{vault_id}/documents.json",
+            error_label="documents")
 
     def get_document(self, project_id, document_id):
         """Get a single document."""
@@ -1412,16 +1326,12 @@ class BasecampClient:
 
     # Upload methods
     def get_uploads(self, project_id, vault_id=None):
-        """List uploads in a project or vault."""
+        """List uploads in a project or vault, handling pagination."""
         if vault_id:
             endpoint = f"buckets/{project_id}/vaults/{vault_id}/uploads.json"
         else:
             endpoint = f"buckets/{project_id}/uploads.json"
-        response = self.get(endpoint)
-        if response.status_code == 200:
-            return response.json()
-        else:
-            raise Exception(f"Failed to get uploads: {response.status_code} - {response.text}")
+        return self.get_all_pages(endpoint, error_label="uploads")
 
     def get_upload(self, project_id, upload_id):
         """Get a single upload."""

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Tests for list endpoint pagination.
+
+Basecamp paginates all list endpoints (commonly 15 items per page) and
+advertises further pages via the HTTP ``Link`` header (see
+https://github.com/basecamp/bc3-api#pagination). ``get_all_pages()`` must
+follow ``rel="next"`` links and aggregate every page, so list helpers such
+as ``get_projects()`` return the full collection instead of only the first
+15 items.
+"""
+
+import os
+import sys
+import unittest
+from unittest.mock import Mock, patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+from basecamp_client import BasecampClient
+
+
+def _client():
+    """Return a BasecampClient with dummy OAuth credentials for unit tests."""
+    return BasecampClient(
+        access_token='token', account_id='123',
+        user_agent='test-agent', auth_mode='oauth',
+    )
+
+
+def _page(items, has_next=False):
+    """Build a mock ``requests`` response for one page of a list endpoint."""
+    resp = Mock()
+    resp.status_code = 200
+    resp.text = ''
+    resp.json.return_value = items
+    resp.headers = {}
+    if has_next:
+        resp.headers['Link'] = (
+            '<https://3.basecampapi.com/123/projects.json?page=2>; rel="next"'
+        )
+    return resp
+
+
+class TestGetAllPages(unittest.TestCase):
+    """get_all_pages() follows Link headers and aggregates all pages."""
+
+    def test_single_page_without_link_header(self):
+        """A single page without a Link header is returned as-is."""
+        client = _client()
+        with patch.object(client, 'get', return_value=_page([{'id': 1}])) as got:
+            result = client.get_all_pages('projects.json')
+        self.assertEqual(result, [{'id': 1}])
+        got.assert_called_once_with('projects.json', params={'page': 1})
+
+    def test_multiple_pages_are_aggregated(self):
+        """Pages are fetched until no rel="next" link remains."""
+        client = _client()
+        pages = [
+            _page([{'id': i} for i in range(1, 16)], has_next=True),
+            _page([{'id': i} for i in range(16, 31)], has_next=True),
+            _page([{'id': i} for i in range(31, 45)]),
+        ]
+        with patch.object(client, 'get', side_effect=pages) as got:
+            result = client.get_all_pages('projects.json')
+        self.assertEqual(len(result), 44)
+        self.assertEqual(got.call_count, 3)
+        got.assert_any_call('projects.json', params={'page': 3})
+
+    def test_empty_page_stops_iteration(self):
+        """An empty page ends pagination even if a Link header is present."""
+        client = _client()
+        with patch.object(client, 'get', return_value=_page([], has_next=True)):
+            result = client.get_all_pages('projects.json')
+        self.assertEqual(result, [])
+
+    def test_error_status_raises_with_label(self):
+        """Non-200 responses raise an exception using the error label."""
+        client = _client()
+        resp = Mock()
+        resp.status_code = 401
+        resp.text = 'unauthorized'
+        with patch.object(client, 'get', return_value=resp):
+            with self.assertRaises(Exception) as ctx:
+                client.get_all_pages('projects.json', error_label='projects')
+        self.assertIn('Failed to get projects', str(ctx.exception))
+
+    def test_extra_params_are_preserved_across_pages(self):
+        """Caller-supplied query params are kept on every page request."""
+        client = _client()
+        pages = [_page([{'id': 1}], has_next=True), _page([{'id': 2}])]
+        with patch.object(client, 'get', side_effect=pages) as got:
+            client.get_all_pages('projects.json', params={'status': 'archived'})
+        got.assert_any_call('projects.json', params={'status': 'archived', 'page': 1})
+        got.assert_any_call('projects.json', params={'status': 'archived', 'page': 2})
+
+
+class TestListEndpointsPaginate(unittest.TestCase):
+    """List helpers fetch all pages instead of only the first 15 items."""
+
+    def test_get_projects_returns_all_pages(self):
+        """get_projects() aggregates beyond the first page of 15 projects."""
+        client = _client()
+        pages = [
+            _page([{'id': i} for i in range(1, 16)], has_next=True),
+            _page([{'id': i} for i in range(16, 21)]),
+        ]
+        with patch.object(client, 'get', side_effect=pages):
+            result = client.get_projects()
+        self.assertEqual(len(result), 20)
+
+    def test_get_people_returns_all_pages(self):
+        """get_people() aggregates beyond the first page."""
+        client = _client()
+        pages = [
+            _page([{'id': i} for i in range(1, 16)], has_next=True),
+            _page([{'id': 16}]),
+        ]
+        with patch.object(client, 'get', side_effect=pages):
+            result = client.get_people()
+        self.assertEqual(len(result), 16)
+
+    def test_get_cards_returns_all_pages(self):
+        """get_cards() aggregates beyond the first page."""
+        client = _client()
+        pages = [
+            _page([{'id': i} for i in range(1, 16)], has_next=True),
+            _page([{'id': 16}]),
+        ]
+        with patch.object(client, 'get', side_effect=pages):
+            result = client.get_cards('1', '2')
+        self.assertEqual(len(result), 16)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -82,7 +82,19 @@ class TestGetAllPages(unittest.TestCase):
         with patch.object(client, 'get', return_value=resp):
             with self.assertRaises(Exception) as ctx:
                 client.get_all_pages('projects.json', error_label='projects')
-        self.assertIn('Failed to get projects', str(ctx.exception))
+        self.assertEqual(
+            str(ctx.exception), 'Failed to get projects: 401 - unauthorized')
+
+    def test_persistent_next_page_hits_page_cap(self):
+        """A response that always advertises a next page raises at MAX_PAGES."""
+        client = _client()
+        with patch.object(
+                client, 'get',
+                return_value=_page([{'id': 1}], has_next=True)) as got:
+            with self.assertRaises(Exception) as ctx:
+                client.get_all_pages('projects.json', error_label='projects')
+        self.assertIn('pagination exceeded', str(ctx.exception))
+        self.assertEqual(got.call_count, BasecampClient.MAX_PAGES)
 
     def test_extra_params_are_preserved_across_pages(self):
         """Caller-supplied query params are kept on every page request."""
@@ -129,6 +141,20 @@ class TestListEndpointsPaginate(unittest.TestCase):
         with patch.object(client, 'get', side_effect=pages):
             result = client.get_cards('1', '2')
         self.assertEqual(len(result), 16)
+
+    def test_get_schedule_entries_uses_dock_schedule(self):
+        """get_schedule_entries() resolves the schedule from the project dock."""
+        client = _client()
+        entries = [{'id': 1}, {'id': 2}]
+        with patch.object(client, 'get_project',
+                          return_value={'dock': [{'name': 'schedule', 'id': 42}]}), \
+                patch.object(client, 'get_all_pages',
+                             return_value=entries) as get_all_pages:
+            result = client.get_schedule_entries('1')
+        self.assertEqual(result, entries)
+        get_all_pages.assert_called_once_with(
+            'buckets/1/schedules/42/entries.json',
+            error_label='schedule entries')
 
 
 if __name__ == '__main__':

--- a/tests/test_token_storage.py
+++ b/tests/test_token_storage.py
@@ -21,6 +21,8 @@ def test_store_token_expands_configured_token_path(configured_path, tmp_path, mo
 
     monkeypatch.chdir(working_dir)
     monkeypatch.setenv("HOME", str(home_dir))
+    # Windows resolves "~" via USERPROFILE instead of HOME.
+    monkeypatch.setenv("USERPROFILE", str(home_dir))
     monkeypatch.setenv("BASECAMP_MCP_TOKEN_FILE", configured_path)
 
     reloaded_token_storage = importlib.reload(token_storage)


### PR DESCRIPTION
## Summary

Basecamp paginates all list endpoints at 15 items per page and advertises further pages via the `Link` header ([API docs](https://github.com/basecamp/bc3-api#pagination)). Only five helpers followed it (`get_todos`, `get_todolist_groups`, `get_messages`, `get_forwards`, `get_inbox_replies`); all other list helpers silently returned just the first page — e.g. `get_projects` showed at most 15 projects, which is quite misleading on accounts with more.

This is the same root cause as #12, applied across the board.

## Changes

- Extract the existing pagination loop into a shared `BasecampClient.get_all_pages()` helper (follows `page` param + `rel="next"` in the `Link` header, stops on empty pages).
- Use it in all list helpers: `get_projects`, `get_todolists`, `get_people`, `get_campfires`, `get_campfire_lines`, `get_message_categories`, `get_schedule_entries`, `get_cards`, `get_events`, `get_webhooks`, `get_documents`, `get_uploads` — plus the five that already paginated, removing ~185 lines of duplicated loop code.
- Repair `get_schedule_entries`: it compared a `requests.Response` object against `list` and therefore always returned `[]`. It now discovers the schedule ID from the project dock (same pattern as `get_todoset`).
- Add `tests/test_pagination.py` covering the helper (multi-page aggregation, empty-page stop, error label, param preservation) and paginated list helpers.

Helpers with an explicit caller-controlled `page` parameter (`get_comments`, `get_daily_check_ins`, `get_question_answers`) are intentionally left unchanged.

## Testing

- Full test suite passes: 55 tests (47 existing + 8 new).
- Tested against a production Basecamp account with 44 projects: `get_projects` previously returned 15 projects, now returns all 44. Deployed and verified via the MCP endpoint (Claude as MCP client).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added shared pagination support to automatically aggregate results across pages (with a safety page cap).

* **Bug Fixes**
  * List views now return all available items (not just the first page).
  * Schedule entries now correctly resolve the schedule via project dock data and load properly when available.

* **Tests**
  * Added/expanded pagination tests for single/multi-page aggregation, empty-page stopping, error messaging, parameter preservation, page-cap enforcement, and schedule dock resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->