### PR TITLE
ci: run test suite via GitHub Actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches: [main]
   pull_request:
+  workflow_dispatch:
 
 jobs:
   pytest:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,30 @@
+# file generated with AI assistance: Claude Code - 2026-07-10 12:00:00 UTC
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run tests
+        run: python -m pytest tests/ -v

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,9 +15,9 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip


### PR DESCRIPTION
## Summary

This adds a GitHub Actions workflow that runs the pytest suite on every push to `main`, on every pull request, and on demand via `workflow_dispatch`, across Python 3.10–3.12 (the versions supported by the MCP SDK and recommended in the README).

I checked existing issues, PRs and discussions first — CI has not been discussed or planned yet, and the repo has no `.github/` directory so far, so this should not conflict with anything in flight.

## Why

The repo has a growing test suite (47 tests on current `main`), and recent PRs (e.g. #33, #34, #35) rely on it for regression coverage. Running it automatically on every PR catches regressions before review and gives contributors immediate feedback.

## Details

- Trigger: `push` to `main`, all `pull_request` events, manual `workflow_dispatch`
- Matrix: Python 3.10, 3.11, 3.12 with `fail-fast: false` and pip caching
- Actions: `checkout@v5` / `setup-python@v6` (Node-24-based, no deprecation warnings)
- Install: `pip install -r requirements.txt` (already includes `pytest` and `mcp[cli]`)
- Run: `python -m pytest tests/ -v`

## Verification

Verified in our fork before opening this PR: [run 29084003116](https://github.com/dmstr-forks/georgeantonopoulos-basecamp-mcp-server/actions/runs/29084003116) — all three matrix jobs green (47 passed each), no runner warnings.

Possible follow-ups (out of scope here):
- add `windows-latest` to the matrix once #35 (which includes a Windows test-portability fix) is merged
- bump the `pytest==7.4.0` pin in `requirements.txt` to 8.x if Python 3.13+ should join the matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)