### PR TITLE
fix: centralize project dock item lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ All notable changes to this project are documented here. The format is based on 
 
 ### Fixed
 
+- Project dock lookups for to-do sets, message boards, inboxes, and schedules
+  now share consistent handling for missing or malformed dock data.
 - All list helpers now follow Basecamp's `Link` header pagination via a shared
   `get_all_pages()` helper. Previously only `get_todos`, `get_todolist_groups`,
   `get_messages`, `get_forwards`, and `get_inbox_replies` paginated; the other

--- a/basecamp_client.py
+++ b/basecamp_client.py
@@ -207,14 +207,23 @@ class BasecampClient:
         else:
             raise Exception(f"Failed to get project: {response.status_code} - {response.text}")
 
+    def _find_dock_item(self, project, name):
+        """Return a named project dock item, or None when it is unavailable."""
+        try:
+            return next(item for item in project["dock"] if item["name"] == name)
+        except (KeyError, TypeError, StopIteration):
+            return None
+
     # To-do list methods
     def get_todoset(self, project_id):
         """Get the todoset for a project (Basecamp 3 has one todoset per project)."""
         project = self.get_project(project_id)
-        try:
-            return next(_ for _ in project["dock"] if _["name"] == "todoset")
-        except (IndexError, TypeError, StopIteration):
-            raise Exception(f"Failed to get todoset for project: {project.id}. Project response: {project}")
+        dock_item = self._find_dock_item(project, "todoset")
+        if dock_item is None:
+            raise Exception(
+                f"Failed to get todoset for project: {project_id}. "
+                f"Project response: {project}")
+        return dock_item
     
     def get_todolists(self, project_id):
         """Get all todolists for a project."""
@@ -600,16 +609,16 @@ class BasecampClient:
             dict: Message board details including id, title, messages_count, etc.
         """
         project = self.get_project(project_id)
-        try:
-            dock_item = next(_ for _ in project["dock"] if _["name"] == "message_board")
-            board_id = dock_item['id']
-            response = self.get(f'buckets/{project_id}/message_boards/{board_id}.json')
-            if response.status_code == 200:
-                return response.json()
-            else:
-                raise Exception(f"Failed to get message board: {response.status_code} - {response.text}")
-        except (IndexError, TypeError, StopIteration):
+        dock_item = self._find_dock_item(project, "message_board")
+        if dock_item is None:
             raise Exception(f"No message board found for project: {project_id}")
+
+        board_id = dock_item['id']
+        response = self.get(f'buckets/{project_id}/message_boards/{board_id}.json')
+        if response.status_code == 200:
+            return response.json()
+        else:
+            raise Exception(f"Failed to get message board: {response.status_code} - {response.text}")
 
     def get_messages(self, project_id, message_board_id=None):
         """Get all messages from a message board, handling pagination.
@@ -710,16 +719,16 @@ class BasecampClient:
             dict: Inbox details including forwards_count, forwards_url, etc.
         """
         project = self.get_project(project_id)
-        try:
-            dock_item = next(_ for _ in project["dock"] if _["name"] == "inbox")
-            inbox_id = dock_item['id']
-            response = self.get(f'buckets/{project_id}/inboxes/{inbox_id}.json')
-            if response.status_code == 200:
-                return response.json()
-            else:
-                raise Exception(f"Failed to get inbox: {response.status_code} - {response.text}")
-        except (IndexError, TypeError, StopIteration):
+        dock_item = self._find_dock_item(project, "inbox")
+        if dock_item is None:
             raise Exception(f"No inbox found for project: {project_id}")
+
+        inbox_id = dock_item['id']
+        response = self.get(f'buckets/{project_id}/inboxes/{inbox_id}.json')
+        if response.status_code == 200:
+            return response.json()
+        else:
+            raise Exception(f"Failed to get inbox: {response.status_code} - {response.text}")
 
     def get_forwards(self, project_id, inbox_id=None):
         """Get all forwards from an inbox, handling pagination.
@@ -830,9 +839,8 @@ class BasecampClient:
         # The schedule ID is discovered from the project's dock array,
         # following the same pattern as get_todoset().
         project = self.get_project(project_id)
-        try:
-            dock_item = next(_ for _ in project["dock"] if _["name"] == "schedule")
-        except (KeyError, TypeError, StopIteration):
+        dock_item = self._find_dock_item(project, "schedule")
+        if dock_item is None:
             return []
 
         return self.get_all_pages(

--- a/basecamp_client.py
+++ b/basecamp_client.py
@@ -210,9 +210,18 @@ class BasecampClient:
     def _find_dock_item(self, project, name):
         """Return a named project dock item, or None when it is unavailable."""
         try:
-            return next(item for item in project["dock"] if item["name"] == name)
-        except (KeyError, TypeError, StopIteration):
+            dock = project["dock"]
+        except (KeyError, TypeError):
             return None
+
+        try:
+            for item in dock:
+                if isinstance(item, dict) and item.get("name") == name:
+                    return item
+        except TypeError:
+            return None
+
+        return None
 
     # To-do list methods
     def get_todoset(self, project_id):
@@ -220,9 +229,7 @@ class BasecampClient:
         project = self.get_project(project_id)
         dock_item = self._find_dock_item(project, "todoset")
         if dock_item is None:
-            raise Exception(
-                f"Failed to get todoset for project: {project_id}. "
-                f"Project response: {project}")
+            raise Exception(f"Failed to get todoset for project: {project_id}")
         return dock_item
     
     def get_todolists(self, project_id):

--- a/tests/test_dock_lookup.py
+++ b/tests/test_dock_lookup.py
@@ -27,6 +27,7 @@ class TestDockLookup(unittest.TestCase):
         project = {
             'dock': [
                 {'name': 'todoset', 'id': 1},
+                {},
                 {'name': 'schedule', 'id': 2},
             ],
         }
@@ -51,9 +52,9 @@ class TestDockLookup(unittest.TestCase):
     def test_get_todoset_reports_missing_dock(self):
         client = _client()
         with patch.object(client, 'get_project', return_value={}):
-            with self.assertRaisesRegex(
-                    Exception, 'Failed to get todoset for project: 1'):
+            with self.assertRaisesRegex(Exception, 'Failed to get todoset for project: 1') as ctx:
                 client.get_todoset('1')
+        self.assertEqual(str(ctx.exception), 'Failed to get todoset for project: 1')
 
     def test_get_todoset_returns_named_dock_item(self):
         client = _client()
@@ -105,6 +106,18 @@ class TestDockLookup(unittest.TestCase):
             result = client.get_schedule_entries('1')
         self.assertEqual(result, [])
         get_all_pages.assert_not_called()
+
+    def test_get_schedule_entries_uses_named_dock_item(self):
+        client = _client()
+        project = {'dock': [{'name': 'schedule', 'id': 42}]}
+        with patch.object(client, 'get_project', return_value=project), \
+                patch.object(client, 'get_all_pages', return_value=[{'id': 1}]) as get_all_pages:
+            result = client.get_schedule_entries('1')
+        self.assertEqual(result, [{'id': 1}])
+        get_all_pages.assert_called_once_with(
+            'buckets/1/schedules/42/entries.json',
+            error_label='schedule entries',
+        )
 
 
 if __name__ == '__main__':

--- a/tests/test_dock_lookup.py
+++ b/tests/test_dock_lookup.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Tests for safe Basecamp project dock lookups."""
+
+import os
+import sys
+import unittest
+from unittest.mock import Mock, patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+from basecamp_client import BasecampClient
+
+
+def _client():
+    """Return a client with dummy OAuth credentials."""
+    return BasecampClient(
+        access_token='token', account_id='123',
+        user_agent='test-agent', auth_mode='oauth',
+    )
+
+
+class TestDockLookup(unittest.TestCase):
+    """Dock-backed helpers handle missing and malformed project data."""
+
+    def test_find_dock_item_returns_named_item(self):
+        client = _client()
+        project = {
+            'dock': [
+                {'name': 'todoset', 'id': 1},
+                {'name': 'schedule', 'id': 2},
+            ],
+        }
+        self.assertEqual(
+            client._find_dock_item(project, 'schedule'),
+            {'name': 'schedule', 'id': 2},
+        )
+
+    def test_find_dock_item_returns_none_for_unusable_data(self):
+        client = _client()
+        projects = (
+            None,
+            {},
+            {'dock': None},
+            {'dock': []},
+            {'dock': [{}]},
+        )
+        for project in projects:
+            with self.subTest(project=project):
+                self.assertIsNone(client._find_dock_item(project, 'schedule'))
+
+    def test_get_todoset_reports_missing_dock(self):
+        client = _client()
+        with patch.object(client, 'get_project', return_value={}):
+            with self.assertRaisesRegex(
+                    Exception, 'Failed to get todoset for project: 1'):
+                client.get_todoset('1')
+
+    def test_get_todoset_returns_named_dock_item(self):
+        client = _client()
+        todoset = {'name': 'todoset', 'id': 42}
+        with patch.object(
+                client, 'get_project', return_value={'dock': [todoset]}):
+            self.assertEqual(client.get_todoset('1'), todoset)
+
+    def test_get_message_board_reports_missing_dock(self):
+        client = _client()
+        with patch.object(client, 'get_project', return_value={}):
+            with self.assertRaisesRegex(
+                    Exception, 'No message board found for project: 1'):
+                client.get_message_board('1')
+
+    def test_get_message_board_uses_named_dock_item(self):
+        client = _client()
+        response = Mock(status_code=200)
+        response.json.return_value = {'id': 42}
+        project = {'dock': [{'name': 'message_board', 'id': 42}]}
+        with patch.object(client, 'get_project', return_value=project), \
+                patch.object(client, 'get', return_value=response) as get:
+            result = client.get_message_board('1')
+        self.assertEqual(result, {'id': 42})
+        get.assert_called_once_with('buckets/1/message_boards/42.json')
+
+    def test_get_inbox_reports_missing_dock(self):
+        client = _client()
+        with patch.object(client, 'get_project', return_value={}):
+            with self.assertRaisesRegex(
+                    Exception, 'No inbox found for project: 1'):
+                client.get_inbox('1')
+
+    def test_get_inbox_uses_named_dock_item(self):
+        client = _client()
+        response = Mock(status_code=200)
+        response.json.return_value = {'id': 42}
+        project = {'dock': [{'name': 'inbox', 'id': 42}]}
+        with patch.object(client, 'get_project', return_value=project), \
+                patch.object(client, 'get', return_value=response) as get:
+            result = client.get_inbox('1')
+        self.assertEqual(result, {'id': 42})
+        get.assert_called_once_with('buckets/1/inboxes/42.json')
+
+    def test_get_schedule_entries_returns_empty_for_missing_dock(self):
+        client = _client()
+        with patch.object(client, 'get_project', return_value={}), \
+                patch.object(client, 'get_all_pages', Mock()) as get_all_pages:
+            result = client.get_schedule_entries('1')
+        self.assertEqual(result, [])
+        get_all_pages.assert_not_called()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

Centralizes Basecamp project dock-item lookup in a shared `_find_dock_item()` helper and uses it for to-do sets, message boards, inboxes, and schedules.

## Why

Follow-up review on #35 found inconsistent exception handling in the older dock lookups. They caught `IndexError`, but a missing `project["dock"]` key raises `KeyError`. In `get_todoset()`, the fallback also referenced `project.id` even though project responses are dictionaries, masking the intended error with `AttributeError`.

## Changes

- Add a safe shared dock-item lookup helper.
- Preserve each caller's existing public behavior when the requested dock item is absent.
- Fix the to-do-set error path to report the supplied project ID.
- Add positive, missing, and malformed dock-data regression coverage.
- Document the fix in the changelog.

## Impact

Projects with missing or malformed dock data now receive the intended empty result or descriptive exception instead of leaking `KeyError` or `AttributeError`. Valid dock lookups are unchanged.

## Validation

- `python -m pytest tests/test_dock_lookup.py -q` — 9 passed
- `python -m pytest -q` — 66 passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved dock lookups for to-do sets, message boards, inboxes, and schedules with consistent handling when dock data is missing or malformed.
  - Standardized error behavior for missing dock items and improved schedule handling to return no entries when dock info is unavailable.
- **Tests**
  - Added new unit tests covering dock selection, missing/malformed dock inputs, and the expected behavior of the affected retrieval helpers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->