### PR TITLE
feat: add Reports API tools (person assignments, assignable people, overdue)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project are documented here. The format is based on 
 
 ### Added
 
+- Reports API tools ([bc-api sections/reports.md](https://github.com/basecamp/bc-api/blob/master/sections/reports.md)): `get_assignable_people` (`GET /reports/todos/assigned.json`), `get_person_assignments` (`GET /reports/todos/assigned/{person_id}.json` with optional `group_by: bucket|date`) and `get_overdue_todos` (`GET /reports/todos/overdue.json`). `get_person_assignments` returns one person's active, pending to-dos across all projects in a single call — previously this required iterating every project and todolist, which was slow and easy to get wrong (missed projects read as "no assignments"). The embedded `todos` list follows `Link`-header pagination defensively and merges pages into one report.
 - `publish` option for `create_message` and `create_document`. The tools still
   publish immediately by default, and callers can pass `publish: false` to omit
   `status: "active"` and create a Basecamp draft instead.

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ python -m pytest tests/ -v
 
 ## Available Tools
 
-The FastMCP server exposes 79 tools.
+The FastMCP server exposes 82 tools.
 
 ### Projects And Search
 
@@ -142,6 +142,17 @@ The FastMCP server exposes 79 tools.
 - `get_project`
 - `search_basecamp`
 - `global_search`
+
+### Reports
+
+- `get_assignable_people` — all people who can have to-dos assigned to them
+  (`GET /reports/todos/assigned.json`)
+- `get_person_assignments` — all active, pending to-dos assigned to one
+  person across **all** projects (`GET /reports/todos/assigned/{id}.json`,
+  optional `group_by: bucket|date`). Prefer this over iterating projects
+  when you need everything assigned to a single person.
+- `get_overdue_todos` — all overdue to-dos across all projects, grouped by
+  lateness (`GET /reports/todos/overdue.json`)
 
 ### Todos
 

--- a/basecamp_client.py
+++ b/basecamp_client.py
@@ -590,6 +590,83 @@ class BasecampClient:
         """Get all people in the account, handling pagination."""
         return self.get_all_pages('people.json', error_label="people")
 
+    # Report methods
+    def get_assignable_people(self):
+        """Get all people who can have to-dos assigned to them.
+
+        Wraps `GET /reports/todos/assigned.json`. Useful for building a list
+        of people to then retrieve their individual to-do assignments via
+        get_person_assignments().
+
+        Returns:
+            list: Person objects (id, name, email_address, title, ...)
+        """
+        return self.get_all_pages('reports/todos/assigned.json',
+                                  error_label="assignable people")
+
+    def get_person_assignments(self, person_id, group_by=None):
+        """Get all active, pending to-dos assigned to a specific person.
+
+        Wraps `GET /reports/todos/assigned/{person_id}.json` — the API
+        counterpart of the web report at
+        `/reports/todos/assigned/{person_id}`. Unlike per-project todo
+        listings, this returns the person's assignments across ALL projects
+        in one call.
+
+        Args:
+            person_id (str): The person's ID
+            group_by (str, optional): 'bucket' groups to-dos by project,
+                'date' groups by due date. API default: 'bucket'.
+
+        Returns:
+            dict: {person, grouped_by, todos} where todos spans all projects
+        """
+        endpoint = f'reports/todos/assigned/{person_id}.json'
+        params = {'group_by': group_by} if group_by else None
+
+        # The response is a single object, but the embedded todos list may be
+        # paginated via the Link header like other list endpoints. Follow
+        # `rel="next"` and merge the todos arrays defensively.
+        result = None
+        page = 1
+        while True:
+            if page > self.MAX_PAGES:
+                raise Exception(
+                    f"Failed to get person assignments: pagination exceeded "
+                    f"{self.MAX_PAGES} pages for endpoint {endpoint}")
+            page_params = dict(params or {}, page=page) if page > 1 else params
+            response = self.get(endpoint, params=page_params)
+            if response.status_code != 200:
+                raise Exception(f"Failed to get person assignments: {response.status_code} - {response.text}")
+
+            data = response.json() or {}
+            if result is None:
+                result = data
+            else:
+                result.setdefault('todos', []).extend(data.get('todos') or [])
+
+            link_header = response.headers.get("Link", "")
+            if not data.get('todos') or 'rel="next"' not in link_header:
+                break
+
+            page += 1
+
+        return result
+
+    def get_overdue_todos(self):
+        """Get all overdue to-dos across all projects, grouped by lateness.
+
+        Wraps `GET /reports/todos/overdue.json`.
+
+        Returns:
+            dict: Groups `under_a_week_late`, `over_a_week_late`,
+                `over_a_month_late`, `over_three_months_late`
+        """
+        response = self.get('reports/todos/overdue.json')
+        if response.status_code != 200:
+            raise Exception(f"Failed to get overdue todos: {response.status_code} - {response.text}")
+        return response.json()
+
     # Campfire (chat) methods
     def get_campfires(self, project_id):
         """Get the campfires for a project, handling pagination."""

--- a/basecamp_client.py
+++ b/basecamp_client.py
@@ -126,7 +126,8 @@ class BasecampClient:
     def get(self, endpoint, params=None):
         """Make a GET request to the Basecamp API."""
         url = f"{self.base_url}/{endpoint}"
-        return requests.get(url, auth=self.auth, headers=self.headers, params=params)
+        return requests.get(url, auth=self.auth, headers=self.headers, params=params,
+                            timeout=(10, 300))
 
     def get_all_pages(self, endpoint, params=None, error_label="items"):
         """Fetch all pages of a list endpoint, following pagination.

--- a/basecamp_fastmcp.py
+++ b/basecamp_fastmcp.py
@@ -269,6 +269,105 @@ async def search_basecamp(query: str, project_id: Optional[str] = None) -> Dict[
         }
 
 @mcp.tool()
+async def get_assignable_people() -> Dict[str, Any]:
+    """Get all people who can have to-dos assigned to them.
+
+    Returns the account-wide list of assignable people (id, name,
+    email_address, title, ...). Use a person's id with
+    get_person_assignments to fetch their to-dos across all projects.
+    """
+    client = _get_basecamp_client()
+    if not client:
+        return _get_auth_error_response()
+
+    try:
+        people = await _run_sync(client.get_assignable_people)
+        return {
+            "status": "success",
+            "people": people,
+            "count": len(people)
+        }
+    except Exception as e:
+        logger.error(f"Error getting assignable people: {e}")
+        if "401" in str(e) and "expired" in str(e).lower():
+            return {
+                "error": "OAuth token expired",
+                "message": "Your Basecamp OAuth token expired during the API call. Please re-authenticate by visiting http://localhost:8000 and completing the OAuth flow again."
+            }
+        return {
+            "error": "Execution error",
+            "message": str(e)
+        }
+
+@mcp.tool()
+async def get_person_assignments(person_id: str, group_by: Optional[str] = None) -> Dict[str, Any]:
+    """Get all active, pending to-dos assigned to a specific person.
+
+    Cross-project report: returns the person's assignments across ALL
+    projects in one call (API counterpart of the web report at
+    /reports/todos/assigned/{person_id}). Prefer this over iterating
+    projects when you need everything assigned to one person.
+
+    Args:
+        person_id: The person's ID (see get_assignable_people)
+        group_by: Optional grouping — 'bucket' (by project, API default)
+            or 'date' (by due date)
+    """
+    client = _get_basecamp_client()
+    if not client:
+        return _get_auth_error_response()
+
+    try:
+        report = await _run_sync(client.get_person_assignments, person_id, group_by)
+        return {
+            "status": "success",
+            "person": report.get("person"),
+            "grouped_by": report.get("grouped_by"),
+            "todos": report.get("todos", []),
+            "count": len(report.get("todos") or [])
+        }
+    except Exception as e:
+        logger.error(f"Error getting assignments for person {person_id}: {e}")
+        if "401" in str(e) and "expired" in str(e).lower():
+            return {
+                "error": "OAuth token expired",
+                "message": "Your Basecamp OAuth token expired during the API call. Please re-authenticate by visiting http://localhost:8000 and completing the OAuth flow again."
+            }
+        return {
+            "error": "Execution error",
+            "message": str(e)
+        }
+
+@mcp.tool()
+async def get_overdue_todos() -> Dict[str, Any]:
+    """Get all overdue to-dos across all projects, grouped by lateness.
+
+    Groups: under_a_week_late, over_a_week_late, over_a_month_late,
+    over_three_months_late.
+    """
+    client = _get_basecamp_client()
+    if not client:
+        return _get_auth_error_response()
+
+    try:
+        report = await _run_sync(client.get_overdue_todos)
+        return {
+            "status": "success",
+            "overdue": report
+        }
+    except Exception as e:
+        logger.error(f"Error getting overdue todos: {e}")
+        if "401" in str(e) and "expired" in str(e).lower():
+            return {
+                "error": "OAuth token expired",
+                "message": "Your Basecamp OAuth token expired during the API call. Please re-authenticate by visiting http://localhost:8000 and completing the OAuth flow again."
+            }
+        return {
+            "error": "Execution error",
+            "message": str(e)
+        }
+
+@mcp.tool()
 async def get_todolists(project_id: str) -> Dict[str, Any]:
     """Get todo lists for a project.
     

--- a/basecamp_fastmcp.py
+++ b/basecamp_fastmcp.py
@@ -10,7 +10,7 @@ import base64
 import logging
 import os
 import sys
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Literal, Optional
 import anyio
 import httpx
 from mcp.server.fastmcp import FastMCP
@@ -300,7 +300,7 @@ async def get_assignable_people() -> Dict[str, Any]:
         }
 
 @mcp.tool()
-async def get_person_assignments(person_id: str, group_by: Optional[str] = None) -> Dict[str, Any]:
+async def get_person_assignments(person_id: str, group_by: Optional[Literal["bucket", "date"]] = None) -> Dict[str, Any]:
     """Get all active, pending to-dos assigned to a specific person.
 
     Cross-project report: returns the person's assignments across ALL

--- a/mcp_server_cli.py
+++ b/mcp_server_cli.py
@@ -760,6 +760,40 @@ class MCPServer:
                     },
                     "required": ["project_id", "document_id"]
                 }
+            },
+            {
+                "name": "get_assignable_people",
+                "description": "Get all people who can have to-dos assigned to them (account-wide). Use a person's id with get_person_assignments to fetch their to-dos across all projects.",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {},
+                    "required": []
+                }
+            },
+            {
+                "name": "get_person_assignments",
+                "description": "Get all active, pending to-dos assigned to a specific person across ALL projects in one call (API counterpart of the web report at /reports/todos/assigned/{person_id}).",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "person_id": {"type": "string", "description": "The person's ID (see get_assignable_people)"},
+                        "group_by": {
+                            "type": "string",
+                            "enum": ["bucket", "date"],
+                            "description": "Optional grouping — 'bucket' (by project, API default) or 'date' (by due date)"
+                        }
+                    },
+                    "required": ["person_id"]
+                }
+            },
+            {
+                "name": "get_overdue_todos",
+                "description": "Get all overdue to-dos across all projects, grouped by lateness (under_a_week_late, over_a_week_late, over_a_month_late, over_three_months_late).",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {},
+                    "required": []
+                }
             }
         ]
 
@@ -1572,6 +1606,33 @@ class MCPServer:
                 return {
                     "status": "success",
                     "message": "Document trashed"
+                }
+
+            elif tool_name == "get_assignable_people":
+                people = client.get_assignable_people()
+                return {
+                    "status": "success",
+                    "people": people,
+                    "count": len(people)
+                }
+
+            elif tool_name == "get_person_assignments":
+                person_id = arguments.get("person_id")
+                group_by = arguments.get("group_by")
+                report = client.get_person_assignments(person_id, group_by)
+                return {
+                    "status": "success",
+                    "person": report.get("person"),
+                    "grouped_by": report.get("grouped_by"),
+                    "todos": report.get("todos", []),
+                    "count": len(report.get("todos") or [])
+                }
+
+            elif tool_name == "get_overdue_todos":
+                report = client.get_overdue_todos()
+                return {
+                    "status": "success",
+                    "overdue": report
                 }
 
             else:

--- a/tests/test_assignment_reports.py
+++ b/tests/test_assignment_reports.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Tests for the Reports API helpers.
+
+Covers the three read-only report endpoints
+(https://github.com/basecamp/bc-api/blob/master/sections/reports.md):
+
+- ``get_assignable_people()`` — ``GET /reports/todos/assigned.json``
+- ``get_person_assignments()`` — ``GET /reports/todos/assigned/{id}.json``,
+  the cross-project per-person assignment report
+- ``get_overdue_todos()`` — ``GET /reports/todos/overdue.json``
+
+The per-person report returns a single JSON object (``person``,
+``grouped_by``, ``todos``); if the API paginates the embedded ``todos``
+list via the ``Link`` header, the pages must be merged into one report.
+"""
+
+import os
+import sys
+import unittest
+from unittest.mock import Mock, patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+from basecamp_client import BasecampClient
+
+
+def _client():
+    """Return a BasecampClient with dummy OAuth credentials for unit tests."""
+    return BasecampClient(
+        access_token='token', account_id='123',
+        user_agent='test-agent', auth_mode='oauth',
+    )
+
+
+def _response(payload, has_next=False, status_code=200, text=''):
+    """Build a mock ``requests`` response for a report endpoint."""
+    resp = Mock()
+    resp.status_code = status_code
+    resp.text = text
+    resp.json.return_value = payload
+    resp.headers = {}
+    if has_next:
+        resp.headers['Link'] = (
+            '<https://3.basecampapi.com/123/reports/todos/assigned/1.json'
+            '?page=2>; rel="next"'
+        )
+    return resp
+
+
+class TestGetAssignablePeople(unittest.TestCase):
+    """get_assignable_people() lists everyone who can receive to-dos."""
+
+    def test_uses_report_endpoint_and_aggregates_pages(self):
+        """The report endpoint is paginated like other list endpoints."""
+        client = _client()
+        pages = [
+            _response([{'id': i} for i in range(1, 16)], has_next=True),
+            _response([{'id': 16}]),
+        ]
+        with patch.object(client, 'get', side_effect=pages) as got:
+            result = client.get_assignable_people()
+        self.assertEqual(len(result), 16)
+        got.assert_any_call('reports/todos/assigned.json', params={'page': 1})
+
+
+class TestGetPersonAssignments(unittest.TestCase):
+    """get_person_assignments() returns one person's cross-project report."""
+
+    def test_single_page_returns_report_object(self):
+        """A single-page response is returned unchanged."""
+        client = _client()
+        report = {
+            'person': {'id': 1, 'name': 'Amy Rivera'},
+            'grouped_by': 'bucket',
+            'todos': [{'id': 10}, {'id': 11}],
+        }
+        with patch.object(client, 'get',
+                          return_value=_response(report)) as got:
+            result = client.get_person_assignments('1')
+        self.assertEqual(result, report)
+        got.assert_called_once_with(
+            'reports/todos/assigned/1.json', params=None)
+
+    def test_group_by_is_passed_as_query_parameter(self):
+        """group_by='date' reaches the API as a query parameter."""
+        client = _client()
+        report = {'person': {'id': 1}, 'grouped_by': 'date', 'todos': []}
+        with patch.object(client, 'get',
+                          return_value=_response(report)) as got:
+            client.get_person_assignments('1', group_by='date')
+        got.assert_called_once_with(
+            'reports/todos/assigned/1.json', params={'group_by': 'date'})
+
+    def test_paginated_todos_are_merged_into_one_report(self):
+        """Link-header pagination merges todos while keeping the person."""
+        client = _client()
+        pages = [
+            _response({'person': {'id': 1}, 'grouped_by': 'bucket',
+                       'todos': [{'id': 10}]}, has_next=True),
+            _response({'person': {'id': 1}, 'grouped_by': 'bucket',
+                       'todos': [{'id': 11}]}),
+        ]
+        with patch.object(client, 'get', side_effect=pages) as got:
+            result = client.get_person_assignments('1', group_by='bucket')
+        self.assertEqual(result['person'], {'id': 1})
+        self.assertEqual(result['todos'], [{'id': 10}, {'id': 11}])
+        got.assert_any_call(
+            'reports/todos/assigned/1.json',
+            params={'group_by': 'bucket', 'page': 2})
+
+    def test_error_status_raises(self):
+        """Non-200 responses raise with status and body."""
+        client = _client()
+        resp = _response({}, status_code=404, text='not found')
+        with patch.object(client, 'get', return_value=resp):
+            with self.assertRaises(Exception) as ctx:
+                client.get_person_assignments('999')
+        self.assertEqual(
+            str(ctx.exception),
+            'Failed to get person assignments: 404 - not found')
+
+    def test_persistent_next_page_hits_page_cap(self):
+        """A response that always advertises a next page raises at MAX_PAGES."""
+        client = _client()
+
+        def fresh_page(*args, **kwargs):
+            # A new response per call: reusing one mock would alias the
+            # report dict across pages, which real requests never do.
+            return _response({'person': {'id': 1}, 'todos': [{'id': 10}]},
+                             has_next=True)
+
+        with patch.object(client, 'get', side_effect=fresh_page) as got:
+            with self.assertRaises(Exception) as ctx:
+                client.get_person_assignments('1')
+        self.assertIn('pagination exceeded', str(ctx.exception))
+        self.assertEqual(got.call_count, BasecampClient.MAX_PAGES)
+
+
+class TestGetOverdueTodos(unittest.TestCase):
+    """get_overdue_todos() returns the lateness-grouped report."""
+
+    def test_returns_lateness_groups(self):
+        """The overdue report object is returned as-is."""
+        client = _client()
+        report = {
+            'under_a_week_late': [{'id': 1}],
+            'over_a_week_late': [],
+            'over_a_month_late': [],
+            'over_three_months_late': [],
+        }
+        with patch.object(client, 'get',
+                          return_value=_response(report)) as got:
+            result = client.get_overdue_todos()
+        self.assertEqual(result, report)
+        got.assert_called_once_with('reports/todos/overdue.json')
+
+    def test_error_status_raises(self):
+        """Non-200 responses raise with status and body."""
+        client = _client()
+        resp = _response({}, status_code=500, text='boom')
+        with patch.object(client, 'get', return_value=resp):
+            with self.assertRaises(Exception) as ctx:
+                client.get_overdue_todos()
+        self.assertEqual(
+            str(ctx.exception), 'Failed to get overdue todos: 500 - boom')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_cli_server.py
+++ b/tests/test_cli_server.py
@@ -7,8 +7,12 @@ import subprocess
 import sys
 import time
 import pytest
-from unittest.mock import patch
+from unittest.mock import patch, Mock
 import token_storage
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+from mcp_server_cli import MCPServer
 
 def test_cli_server_initialize():
     """Test that the CLI server responds to initialize requests."""
@@ -265,3 +269,95 @@ def test_cli_server_invalid_method():
     finally:
         if proc.poll() is None:
             proc.terminate()
+
+
+# --- Reports API tools (parity with basecamp_fastmcp.py) ---------------------
+#
+# The legacy CLI server is kept for compatibility, so the three Reports tools
+# added to the FastMCP server must also be listed in tools/list and dispatch
+# through _execute_tool() with matching response shapes. These tests exercise
+# the MCPServer class in-process with a mocked Basecamp client (no network).
+
+REPORT_TOOLS = ["get_assignable_people", "get_person_assignments", "get_overdue_todos"]
+
+
+def test_report_tools_registered_in_tools_list():
+    """The three Reports tools appear in the CLI tools/list."""
+    server = MCPServer()
+    tools_by_name = {tool["name"]: tool for tool in server.tools}
+
+    for name in REPORT_TOOLS:
+        assert name in tools_by_name, f"{name} missing from tools/list"
+
+    # get_person_assignments requires person_id and constrains group_by to the
+    # two API-supported values (parity with the FastMCP Literal type).
+    schema = tools_by_name["get_person_assignments"]["inputSchema"]
+    assert schema["required"] == ["person_id"]
+    assert schema["properties"]["group_by"]["enum"] == ["bucket", "date"]
+
+
+@patch.object(MCPServer, "_get_basecamp_client")
+def test_dispatch_get_assignable_people(mock_get_client):
+    """get_assignable_people dispatches and returns people + count."""
+    client = Mock()
+    client.get_assignable_people.return_value = [{"id": 1}, {"id": 2}]
+    mock_get_client.return_value = client
+
+    result = MCPServer()._execute_tool("get_assignable_people", {})
+
+    client.get_assignable_people.assert_called_once_with()
+    assert result["status"] == "success"
+    assert result["people"] == [{"id": 1}, {"id": 2}]
+    assert result["count"] == 2
+
+
+@patch.object(MCPServer, "_get_basecamp_client")
+def test_dispatch_get_person_assignments(mock_get_client):
+    """get_person_assignments passes person_id + group_by and unpacks report."""
+    client = Mock()
+    client.get_person_assignments.return_value = {
+        "person": {"id": 42},
+        "grouped_by": "date",
+        "todos": [{"id": 10}, {"id": 11}],
+    }
+    mock_get_client.return_value = client
+
+    result = MCPServer()._execute_tool(
+        "get_person_assignments", {"person_id": "42", "group_by": "date"}
+    )
+
+    client.get_person_assignments.assert_called_once_with("42", "date")
+    assert result["status"] == "success"
+    assert result["person"] == {"id": 42}
+    assert result["grouped_by"] == "date"
+    assert result["todos"] == [{"id": 10}, {"id": 11}]
+    assert result["count"] == 2
+
+
+@patch.object(MCPServer, "_get_basecamp_client")
+def test_dispatch_get_person_assignments_without_group_by(mock_get_client):
+    """group_by defaults to None when the argument is omitted."""
+    client = Mock()
+    client.get_person_assignments.return_value = {"person": {}, "todos": []}
+    mock_get_client.return_value = client
+
+    result = MCPServer()._execute_tool("get_person_assignments", {"person_id": "7"})
+
+    client.get_person_assignments.assert_called_once_with("7", None)
+    assert result["status"] == "success"
+    assert result["count"] == 0
+
+
+@patch.object(MCPServer, "_get_basecamp_client")
+def test_dispatch_get_overdue_todos(mock_get_client):
+    """get_overdue_todos dispatches and wraps the report under 'overdue'."""
+    client = Mock()
+    report = {"under_a_week_late": [{"id": 1}], "over_a_week_late": []}
+    client.get_overdue_todos.return_value = report
+    mock_get_client.return_value = client
+
+    result = MCPServer()._execute_tool("get_overdue_todos", {})
+
+    client.get_overdue_todos.assert_called_once_with()
+    assert result["status"] == "success"
+    assert result["overdue"] == report

--- a/tests/test_cli_server.py
+++ b/tests/test_cli_server.py
@@ -8,10 +8,10 @@ import sys
 import time
 import pytest
 from unittest.mock import patch, Mock
-import token_storage
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 
+import token_storage
 from mcp_server_cli import MCPServer
 
 def test_cli_server_initialize():


### PR DESCRIPTION
## What

Adds three read-only MCP tools wrapping the Basecamp [Reports API](https://github.com/basecamp/bc-api/blob/master/sections/reports.md):

| Tool | Endpoint |
|---|---|
| `get_assignable_people` | `GET /reports/todos/assigned.json` |
| `get_person_assignments` | `GET /reports/todos/assigned/{person_id}.json` (optional `group_by: bucket\|date`) |
| `get_overdue_todos` | `GET /reports/todos/overdue.json` |

## Why

`get_person_assignments` is the API counterpart of the web report at `/reports/todos/assigned/{person_id}` and returns one person's active, pending to-dos **across all projects in a single call**. Without it, answering "what is assigned to person X?" requires iterating every project and todolist — slow, and projects missed by the iteration silently read as "no assignments" (false negatives in downstream reporting).

`get_assignable_people` provides the person IDs to feed into the report; `get_overdue_todos` is the third report endpoint of the same API section.

## Implementation notes

- All three tools are read-only (`get_*` naming, consistent with the existing toolset).
- `get_assignable_people` uses the shared `get_all_pages` pagination helper.
- The per-person report returns a single JSON object (`person`, `grouped_by`, `todos`); the embedded `todos` list follows `Link`-header pagination defensively and merges pages into one report, guarded by `MAX_PAGES`.
- Error handling mirrors the existing tools (auth check, 401-expired hint).

## Tests

`tests/test_assignment_reports.py` — endpoint/params wiring, `group_by` pass-through, multi-page merge, non-200 errors, `MAX_PAGES` cap. Full suite: **75 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added Reports API–backed tools for assignable people, person assignment to-dos across all projects, and overdue to-dos.
  - `get_person_assignments` supports optional grouping by bucket or due date and returns aggregated results in a single response.
  - Added parity in both the FastMCP server tools and the legacy CLI for compatibility.
- **Bug Fixes**
  - Improved Basecamp request reliability by using explicit timeout settings.
- **Documentation**
  - Updated the changelog and README to list the new Reports tools and revised tool counts.
- **Tests**
  - Added coverage for pagination, grouping, response shape, and error handling for the new Reports tools.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->