### PR TITLE
feat: add completed/status filters to get_todos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project are documented here. The format is based on 
 
 ### Added
 
+- `completed` and `status` parameters for `get_todos`. The Basecamp to-dos
+  endpoint returns only the active (incomplete) to-dos by default; callers can
+  now pass `completed: true` to fetch the completed to-dos, or
+  `status: "archived"`/`"trashed"` to fetch by recording status. The params are
+  threaded through the existing `get_all_pages()` pagination, so completed sets
+  are returned in full rather than only the first page.
 - `publish` option for `create_message` and `create_document`. The tools still
   publish immediately by default, and callers can pass `publish: false` to omit
   `status: "active"` and create a Basecamp draft instead.

--- a/basecamp_client.py
+++ b/basecamp_client.py
@@ -314,16 +314,43 @@ class BasecampClient:
             raise Exception(f"Failed to trash todolist: {response.status_code} - {response.text}")
 
     # To-do methods
-    def get_todos(self, project_id, todolist_id):
-        """Get all todos in a todolist, handling pagination.
+    def get_todos(self, project_id, todolist_id, completed=None, status=None):
+        """Get todos in a todolist, handling pagination.
 
         Basecamp paginates list endpoints (commonly 15 items per page). This
         implementation follows pagination via the `page` query parameter and
         the HTTP `Link` header if present, aggregating all pages before
         returning the combined list.
+
+        By default the Basecamp API returns only the active (incomplete)
+        to-dos. Use `completed` to fetch the completed ones instead, or
+        `status` to fetch archived/trashed to-dos.
+        See https://github.com/basecamp/bc3-api/blob/master/sections/todos.md.
+
+        Args:
+            project_id (str): Project ID
+            todolist_id (str): Todo list ID
+            completed (bool, optional): When True, return completed to-dos
+                (Basecamp's `?completed=true`). When False/None the default
+                active set is returned.
+            status (str, optional): Recording-status filter — 'archived' or
+                'trashed' (Basecamp's `?status=...`).
+
+        Returns:
+            list: All matching todos across all pages.
         """
+        params = {}
+        if completed:
+            params['completed'] = 'true'
+        if status is not None:
+            if status not in ('archived', 'trashed'):
+                raise ValueError(
+                    "status must be 'archived' or 'trashed', got "
+                    f"{status!r}")
+            params['status'] = status
         return self.get_all_pages(
             f'buckets/{project_id}/todolists/{todolist_id}/todos.json',
+            params=params or None,
             error_label="todos")
 
     def get_todo(self, project_id, todo_id):

--- a/basecamp_fastmcp.py
+++ b/basecamp_fastmcp.py
@@ -299,19 +299,32 @@ async def get_todolists(project_id: str) -> Dict[str, Any]:
         }
 
 @mcp.tool()
-async def get_todos(project_id: str, todolist_id: str) -> Dict[str, Any]:
+async def get_todos(
+    project_id: str,
+    todolist_id: str,
+    completed: bool = False,
+    status: Optional[str] = None,
+) -> Dict[str, Any]:
     """Get todos from a todo list.
-    
+
+    By default only the active (incomplete) to-dos are returned. Set
+    ``completed=True`` to fetch the completed to-dos instead (useful for
+    reporting delivered work by title rather than an open/closed ratio), or
+    ``status='archived'``/``'trashed'`` to fetch by recording status.
+
     Args:
         project_id: Project ID
         todolist_id: The todo list ID
+        completed: When True, return completed to-dos (Basecamp ?completed=true)
+        status: Optional recording-status filter: 'archived' or 'trashed'
     """
     client = _get_basecamp_client()
     if not client:
         return _get_auth_error_response()
-    
+
     try:
-        todos = await _run_sync(client.get_todos, project_id, todolist_id)
+        todos = await _run_sync(
+            client.get_todos, project_id, todolist_id, completed, status)
         return {
             "status": "success",
             "todos": todos,

--- a/mcp_server_cli.py
+++ b/mcp_server_cli.py
@@ -89,12 +89,14 @@ class MCPServer:
             },
             {
                 "name": "get_todos",
-                "description": "Get todos from a todo list",
+                "description": "Get todos from a todo list. Returns active (incomplete) to-dos by default; set completed=true for completed to-dos, or status='archived'/'trashed' to filter by recording status.",
                 "inputSchema": {
                     "type": "object",
                     "properties": {
                         "project_id": {"type": "string", "description": "Project ID"},
                         "todolist_id": {"type": "string", "description": "The todo list ID"},
+                        "completed": {"type": "boolean", "description": "When true, return completed to-dos instead of the default active set"},
+                        "status": {"type": "string", "enum": ["archived", "trashed"], "description": "Optional recording-status filter"},
                     },
                     "required": ["project_id", "todolist_id"]
                 }
@@ -954,7 +956,9 @@ class MCPServer:
             elif tool_name == "get_todos":
                 todolist_id = arguments.get("todolist_id")
                 project_id = arguments.get("project_id")
-                todos = client.get_todos(project_id, todolist_id)
+                completed = arguments.get("completed", False)
+                status = arguments.get("status")
+                todos = client.get_todos(project_id, todolist_id, completed, status)
                 return {
                     "status": "success",
                     "todos": todos,

--- a/tests/test_get_todos_filters.py
+++ b/tests/test_get_todos_filters.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Tests for get_todos() completed/status filters.
+
+By default the Basecamp to-dos endpoint returns only the active (incomplete)
+to-dos. get_todos() exposes `completed` and `status` so callers can fetch
+completed or archived/trashed to-dos as well, threading the corresponding
+query params through to the paginated request.
+See https://github.com/basecamp/bc3-api/blob/master/sections/todos.md.
+"""
+
+import os
+import sys
+import unittest
+from unittest.mock import patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+from basecamp_client import BasecampClient
+
+
+def _client():
+    """Return a BasecampClient with dummy OAuth credentials for unit tests."""
+    return BasecampClient(
+        access_token='token', account_id='123',
+        user_agent='test-agent', auth_mode='oauth',
+    )
+
+
+ENDPOINT = 'buckets/1/todolists/2/todos.json'
+
+
+class TestGetTodosFilters(unittest.TestCase):
+    """get_todos() maps completed/status to the right query params."""
+
+    def test_default_sends_no_filter_params(self):
+        client = _client()
+        with patch.object(client, 'get_all_pages', return_value=[]) as gap:
+            client.get_todos('1', '2')
+        gap.assert_called_once_with(ENDPOINT, params=None, error_label='todos')
+
+    def test_completed_true_sends_completed_param(self):
+        client = _client()
+        with patch.object(client, 'get_all_pages', return_value=[]) as gap:
+            client.get_todos('1', '2', completed=True)
+        gap.assert_called_once_with(
+            ENDPOINT, params={'completed': 'true'}, error_label='todos')
+
+    def test_completed_false_is_treated_as_default(self):
+        client = _client()
+        with patch.object(client, 'get_all_pages', return_value=[]) as gap:
+            client.get_todos('1', '2', completed=False)
+        gap.assert_called_once_with(ENDPOINT, params=None, error_label='todos')
+
+    def test_status_archived_sends_status_param(self):
+        client = _client()
+        with patch.object(client, 'get_all_pages', return_value=[]) as gap:
+            client.get_todos('1', '2', status='archived')
+        gap.assert_called_once_with(
+            ENDPOINT, params={'status': 'archived'}, error_label='todos')
+
+    def test_completed_and_status_combine(self):
+        client = _client()
+        with patch.object(client, 'get_all_pages', return_value=[]) as gap:
+            client.get_todos('1', '2', completed=True, status='trashed')
+        gap.assert_called_once_with(
+            ENDPOINT,
+            params={'completed': 'true', 'status': 'trashed'},
+            error_label='todos')
+
+    def test_invalid_status_raises_value_error(self):
+        client = _client()
+        with patch.object(client, 'get_all_pages', return_value=[]):
+            with self.assertRaises(ValueError):
+                client.get_todos('1', '2', status='bogus')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds `completed` and `status` parameters to `get_todos`.

The Basecamp to-dos endpoint returns only the **active (incomplete)** to-dos by default, and there's no project-wide activity feed — so today there's no way to enumerate *delivered* work through `get_todos`. This threads Basecamp's own query params through:

- `completed: true` → `?completed=true` (fetch the completed to-dos)
- `status: "archived" | "trashed"` → `?status=...` (fetch by recording status)

Both are optional; omitting them preserves the existing default-active behaviour. The params flow through the existing `get_all_pages()` helper, so completed sets are returned **in full** (all pages), not just the first 15. Invalid `status` values raise a clear `ValueError`.

Consistent with the recent pagination/param work (#35, #38): the change is wired through `BasecampClient.get_todos` **and both tool surfaces** — the FastMCP server (`basecamp_fastmcp.py`) and the CLI server (`mcp_server_cli.py`).

## Motivation

Downstream we run first-sight backfills of Basecamp projects and could only report delivered work as a ratio (e.g. "~74/111 done") rather than by title, because completed to-dos were unreachable. `completed=true` closes that gap.

Refs: https://github.com/basecamp/bc3-api/blob/master/sections/todos.md

## Tests

`tests/test_get_todos_filters.py` — default (no filter params), `completed=True`, `completed=False` (treated as default), `status='archived'`, combined `completed`+`status`, and invalid-status → `ValueError`. Full suite green (73 passed). Changelog updated under **Unreleased › Added**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added filters for retrieving completed to-dos.
  - Added support for filtering to-dos by archived or trashed status.
  - Filtered results now include all available pages.

- **Bug Fixes**
  - Invalid status values are rejected with a clear validation error.

- **Documentation**
  - Updated the changelog and tool descriptions to explain the new filtering options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->