### PR TITLE
fix: add request timeout to all Basecamp HTTP helpers

### DIFF
--- a/basecamp_client.py
+++ b/basecamp_client.py
@@ -126,7 +126,8 @@ class BasecampClient:
     def get(self, endpoint, params=None):
         """Make a GET request to the Basecamp API."""
         url = f"{self.base_url}/{endpoint}"
-        return requests.get(url, auth=self.auth, headers=self.headers, params=params)
+        return requests.get(url, auth=self.auth, headers=self.headers, params=params,
+                             timeout=(10, 300))
 
     def get_all_pages(self, endpoint, params=None, error_label="items"):
         """Fetch all pages of a list endpoint, following pagination.
@@ -177,22 +178,26 @@ class BasecampClient:
     def post(self, endpoint, data=None):
         """Make a POST request to the Basecamp API."""
         url = f"{self.base_url}/{endpoint}"
-        return requests.post(url, auth=self.auth, headers=self.headers, json=data)
+        return requests.post(url, auth=self.auth, headers=self.headers, json=data,
+                             timeout=(10, 300))
 
     def put(self, endpoint, data=None):
         """Make a PUT request to the Basecamp API."""
         url = f"{self.base_url}/{endpoint}"
-        return requests.put(url, auth=self.auth, headers=self.headers, json=data)
+        return requests.put(url, auth=self.auth, headers=self.headers, json=data,
+                             timeout=(10, 300))
 
     def delete(self, endpoint):
         """Make a DELETE request to the Basecamp API."""
         url = f"{self.base_url}/{endpoint}"
-        return requests.delete(url, auth=self.auth, headers=self.headers)
+        return requests.delete(url, auth=self.auth, headers=self.headers,
+                                timeout=(10, 300))
 
     def patch(self, endpoint, data=None):
         """Make a PATCH request to the Basecamp API."""
         url = f"{self.base_url}/{endpoint}"
-        return requests.patch(url, auth=self.auth, headers=self.headers, json=data)
+        return requests.patch(url, auth=self.auth, headers=self.headers, json=data,
+                              timeout=(10, 300))
 
     # Project methods
     def get_projects(self):


### PR DESCRIPTION
## What

Adds `timeout=(10, 300)` (connect, read) to the `get()`, `post()`, `put()`, `delete()`, and `patch()` HTTP helpers in `basecamp_client.py`.

## Why

Without a timeout, a hanging `requests.*` call blocks indefinitely. These helpers run inside a thread-pool worker via `_run_sync()` in the FastMCP server, so a hang permanently ties up that worker thread.

`download_upload`/`download_attachment` already use `timeout=(10, 300)`. This applies the same value across all remaining HTTP helpers for consistency.

Addresses #40. That issue scoped the fix to `post`/`put`/`delete`/`patch`, expecting `get()` to already have a timeout from #39 — but #39 is still open, so `get()` doesn't have one on `main` yet either. This PR adds the timeout to `get()` too so the fix isn't dependent on #39 landing first, and all five helpers stay consistent.

## Testing

Could not run the test suite locally (no Python interpreter available in this environment), but the change is a minimal, mechanical addition of a keyword argument with no behavior change under normal (non-hanging) conditions. CI (`tests.yml`) will run the full suite on this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added consistent connection and response time limits to all network requests.
  * Improved reliability by preventing requests from waiting indefinitely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->