### PR TITLE
fix: preserve existing to-do fields when updating a subset

### DIFF
--- a/basecamp_client.py
+++ b/basecamp_client.py
@@ -415,42 +415,71 @@ class BasecampClient:
                     completion_subscriber_ids=None, notify=None, due_on=None, starts_on=None):
         """
         Update an existing todo item.
-        
+
+        Fetches the to-do first and merges the caller's fields over its current
+        values, because Basecamp's PUT clears any parameter that is absent from
+        the request:
+
+            "Omitting a parameter will clear its value, for example,
+             empty/missing assignee_ids clears existing assignees.
+             Pass all existing parameters in addition to those being updated."
+            -- https://github.com/basecamp/bc3-api/blob/master/sections/todos.md
+
+        Without this merge, changing one field (e.g. content) silently wipes the
+        to-do's assignees, due date, start date and description.
+
         Args:
             project_id (str): Project ID
             todo_id (str): Todo ID
             content (str, optional): The todo item's text
             description (str, optional): HTML description
-            assignee_ids (list, optional): List of person IDs to assign
-            completion_subscriber_ids (list, optional): List of person IDs to notify on completion
-            notify (bool, optional): Whether to notify assignees
-            due_on (str, optional): Due date in YYYY-MM-DD format
-            starts_on (str, optional): Start date in YYYY-MM-DD format
-            
+            assignee_ids (list, optional): List of person IDs to assign.
+                Pass [] explicitly to clear all assignees.
+            completion_subscriber_ids (list, optional): List of person IDs to
+                notify on completion. Pass [] explicitly to clear.
+            notify (bool, optional): Whether to notify assignees. Transient —
+                it triggers notifications and is not stored on the to-do, so it
+                is only sent when explicitly supplied.
+            due_on (str, optional): Due date in YYYY-MM-DD format.
+                Pass "" explicitly to clear an existing due date.
+            starts_on (str, optional): Start date in YYYY-MM-DD format.
+                Pass "" explicitly to clear an existing start date.
+
         Returns:
             dict: The updated todo
         """
+        if all(value is None for value in (content, description, assignee_ids,
+                                           completion_subscriber_ids, notify,
+                                           due_on, starts_on)):
+            raise ValueError("No fields provided to update")
+
         endpoint = f'buckets/{project_id}/todos/{todo_id}.json'
-        data = {}
-        
-        if content is not None:
-            data['content'] = content
-        if description is not None:
-            data['description'] = description
-        if assignee_ids is not None:
-            data['assignee_ids'] = assignee_ids
-        if completion_subscriber_ids is not None:
-            data['completion_subscriber_ids'] = completion_subscriber_ids
+
+        # Re-send the to-do's existing values for anything the caller omitted.
+        current = self.get_todo(project_id, todo_id)
+        current_assignee_ids = [a['id'] for a in current.get('assignees') or []]
+        current_subscriber_ids = [
+            s['id'] for s in current.get('completion_subscribers') or []
+        ]
+
+        data = {
+            'content': content if content is not None else current.get('content', ''),
+            'description': (description if description is not None
+                            else current.get('description') or ''),
+            'assignee_ids': (assignee_ids if assignee_ids is not None
+                             else current_assignee_ids),
+            'completion_subscriber_ids': (completion_subscriber_ids
+                                          if completion_subscriber_ids is not None
+                                          else current_subscriber_ids),
+            'due_on': due_on if due_on is not None else current.get('due_on'),
+            'starts_on': starts_on if starts_on is not None else current.get('starts_on'),
+        }
+
+        # `notify` is transient rather than stored state, so only pass it through
+        # when the caller asked for it.
         if notify is not None:
             data['notify'] = notify
-        if due_on is not None:
-            data['due_on'] = due_on
-        if starts_on is not None:
-            data['starts_on'] = starts_on
 
-        if not data:
-            raise ValueError("No fields provided to update")
-            
         response = self.put(endpoint, data)
         if response.status_code == 200:
             return response.json()

--- a/basecamp_client.py
+++ b/basecamp_client.py
@@ -428,6 +428,16 @@ class BasecampClient:
         Without this merge, changing one field (e.g. content) silently wipes the
         to-do's assignees, due date, start date and description.
 
+        Known limitation — lost updates: because this reads then writes, an edit
+        made by someone else between the GET and the PUT is overwritten by the
+        values read here. Basecamp's to-do endpoint offers no way to close that
+        window: its ETag / Last-Modified support is for cache validation, not
+        optimistic concurrency, so there is no conditional PUT to make the write
+        depend on the version that was read. The exposure is a few hundred
+        milliseconds, and it replaces an unconditional loss of the omitted
+        fields on every call, but callers performing unattended bulk edits
+        should treat a lost update as possible.
+
         Args:
             project_id (str): Project ID
             todo_id (str): Todo ID

--- a/tests/test_update_todo_preserves_fields.py
+++ b/tests/test_update_todo_preserves_fields.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Tests that update_todo() re-sends existing values for omitted fields.
+
+Basecamp's to-do PUT clears any parameter absent from the request:
+
+    "Omitting a parameter will clear its value, for example, empty/missing
+     assignee_ids clears existing assignees. Pass all existing parameters in
+     addition to those being updated."
+    -- https://github.com/basecamp/bc3-api/blob/master/sections/todos.md
+
+So update_todo() fetches the to-do and merges the caller's fields over its
+current values, rather than sending only what the caller supplied.
+"""
+
+import os
+import sys
+import unittest
+from unittest.mock import Mock, patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+from basecamp_client import BasecampClient
+
+
+def _client():
+    """Return a BasecampClient with dummy OAuth credentials for unit tests."""
+    return BasecampClient(
+        access_token='token', account_id='123',
+        user_agent='test-agent', auth_mode='oauth',
+    )
+
+
+EXISTING_TODO = {
+    'id': 9,
+    'content': 'Original title',
+    'description': '<div>Original description</div>',
+    'assignees': [{'id': 111}, {'id': 222}],
+    'completion_subscribers': [{'id': 333}],
+    'due_on': '2026-01-31',
+    'starts_on': '2026-01-01',
+}
+
+ENDPOINT = 'buckets/1/todos/9.json'
+
+
+def _put_response():
+    response = Mock()
+    response.status_code = 200
+    response.json.return_value = {'id': 9}
+    response.text = ''
+    return response
+
+
+class TestUpdateTodoPreservesFields(unittest.TestCase):
+
+    def _update(self, **kwargs):
+        """Run update_todo against the fixture, returning the PUT payload."""
+        client = _client()
+        with patch.object(client, 'get_todo', return_value=dict(EXISTING_TODO)), \
+                patch.object(client, 'put', return_value=_put_response()) as put:
+            client.update_todo('1', '9', **kwargs)
+        put.assert_called_once()
+        endpoint, payload = put.call_args[0]
+        self.assertEqual(endpoint, ENDPOINT)
+        return payload
+
+    def test_changing_only_content_preserves_everything_else(self):
+        """The regression this guards: a title edit must not wipe assignees."""
+        payload = self._update(content='New title')
+
+        self.assertEqual(payload['content'], 'New title')
+        self.assertEqual(payload['assignee_ids'], [111, 222])
+        self.assertEqual(payload['completion_subscriber_ids'], [333])
+        self.assertEqual(payload['due_on'], '2026-01-31')
+        self.assertEqual(payload['starts_on'], '2026-01-01')
+        self.assertEqual(payload['description'], '<div>Original description</div>')
+
+    def test_changing_only_due_date_preserves_content_and_assignees(self):
+        payload = self._update(due_on='2026-12-25')
+
+        self.assertEqual(payload['due_on'], '2026-12-25')
+        self.assertEqual(payload['content'], 'Original title')
+        self.assertEqual(payload['assignee_ids'], [111, 222])
+
+    def test_empty_list_still_clears_assignees(self):
+        """Passing [] is an explicit clear, not an omission."""
+        payload = self._update(assignee_ids=[])
+        self.assertEqual(payload['assignee_ids'], [])
+
+    def test_empty_string_still_clears_due_date(self):
+        payload = self._update(due_on='')
+        self.assertEqual(payload['due_on'], '')
+
+    def test_notify_omitted_unless_supplied(self):
+        self.assertNotIn('notify', self._update(content='x'))
+        self.assertTrue(self._update(content='x', notify=True)['notify'])
+
+    def test_handles_todo_with_no_assignees_or_dates(self):
+        client = _client()
+        sparse = {'id': 9, 'content': 'Bare', 'description': None,
+                  'assignees': [], 'completion_subscribers': [],
+                  'due_on': None, 'starts_on': None}
+        with patch.object(client, 'get_todo', return_value=sparse), \
+                patch.object(client, 'put', return_value=_put_response()) as put:
+            client.update_todo('1', '9', content='Renamed')
+        payload = put.call_args[0][1]
+        self.assertEqual(payload['assignee_ids'], [])
+        self.assertEqual(payload['description'], '')
+        self.assertIsNone(payload['due_on'])
+
+    def test_no_fields_raises_without_calling_the_api(self):
+        """The pre-existing ValueError contract is kept, and costs no request."""
+        client = _client()
+        with patch.object(client, 'get_todo') as get_todo, \
+                patch.object(client, 'put') as put:
+            with self.assertRaises(ValueError):
+                client.update_todo('1', '9')
+        get_todo.assert_not_called()
+        put.assert_not_called()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## What

`update_todo()` now fetches the to-do and merges the caller's arguments over its current values, instead of building the PUT payload from only the arguments that were supplied.

## Why

Basecamp's to-do update endpoint clears any parameter absent from the request body. From the [bc3-api docs](https://github.com/basecamp/bc3-api/blob/master/sections/todos.md):

> "Omitting a parameter will clear its value, for example, empty/missing `assignee_ids` clears existing assignees."
>
> "Pass _all existing parameters_ in addition to those being updated."

The current implementation only sends what the caller passed, so changing one field silently discards the rest. For example:

```python
client.update_todo(project_id, todo_id, content="New title")
```

clears the to-do's assignees, completion subscribers, due date, start date and description. Via MCP this is easy to trigger unintentionally — "rename this to-do" reads as a narrow edit, but currently unassigns everyone on it.

## Implementation notes

- The to-do is fetched with the existing `get_todo()` before the PUT, and each field falls back to its current value when the caller omitted it.
- Explicit values still clear: passing `[]` for `assignee_ids` / `completion_subscriber_ids`, or `""` for `due_on` / `starts_on`, is treated as an intentional clear rather than an omission. Only `None` (the default) means "leave unchanged".
- `notify` is only forwarded when explicitly supplied. It triggers notification emails rather than being stored state, so replaying it from the fetched to-do would send spurious notifications.
- The pre-existing `ValueError("No fields provided to update")` contract is kept, and now raises *before* the added GET so the no-op case costs no API call.

## Trade-off

This adds one GET per update. That seemed clearly preferable to silent data loss, and it is what the API docs require. Happy to gate it behind a flag (e.g. `merge_existing=True`) instead if you would rather callers opt in.

## Tests

`tests/test_update_todo_preserves_fields.py` covers the content-only and due-date-only cases, explicit clears, `notify` handling, a to-do with no assignees or dates, and the no-fields `ValueError`.

Three of these tests fail against the current implementation and pass with the change. Full suite: **80 passed**.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updating a to-do now preserves existing fields when they’re omitted from the update request, including assignees, completion subscribers, due dates/start dates, and description.
  * Explicit clearing still works as expected (for example, empty lists/empty strings clear assignees/due dates).
  * Notifications are only changed/sent when explicitly provided.
  * Empty updates still return a validation error.
* **Tests**
  * Added coverage to verify omitted-field preservation and correct clearing/validation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
