### PR TITLE
fix: cap mcp below 2.0 so a fresh install still starts

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,9 @@ python-dotenv==1.0.0
 flask==2.3.3
 flask-cors==4.0.0
 pytest==7.4.0
-mcp[cli]>=1.2.0
+# Capped below 2.0: mcp 2.0.0 removed `mcp.server.fastmcp`, which
+# basecamp_fastmcp.py imports. Without the upper bound a fresh install resolves
+# 2.x and the server fails to start with ModuleNotFoundError.
+mcp[cli]>=1.2.0,<2
 httpx>=0.25.0
 anyio>=4.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,9 +3,12 @@ python-dotenv==1.0.0
 flask==2.3.3
 flask-cors==4.0.0
 pytest==7.4.0
-# Capped below 2.0: mcp 2.0.0 removed `mcp.server.fastmcp`, which
-# basecamp_fastmcp.py imports. Without the upper bound a fresh install resolves
-# 2.x and the server fails to start with ModuleNotFoundError.
-mcp[cli]>=1.2.0,<2
+# Upper bound: mcp 2.0.0 removed `mcp.server.fastmcp`, which basecamp_fastmcp.py
+# imports. Without `<2` a fresh install resolves 2.x and the server fails to
+# start with ModuleNotFoundError.
+# Lower bound: 1.28.1 is the first release patched against all known 1.x
+# advisories — CVE-2026-59950 (< 1.28.1), CVE-2026-52869 and CVE-2026-52870
+# (<= 1.27.1).
+mcp[cli]>=1.28.1,<2
 httpx>=0.25.0
 anyio>=4.0.0


### PR DESCRIPTION
## What

Changes `requirements.txt` from `mcp[cli]>=1.2.0` to `mcp[cli]>=1.2.0,<2`.

## Why

`mcp` **2.0.0** was published today (2026-07-28 13:45 UTC) and removed `mcp.server.fastmcp` — the `mcp/server/` tree now ships `mcpserver` instead, and there is no alias or compatibility shim. `basecamp_fastmcp.py` imports the 1.x path:

```python
from mcp.server.fastmcp import FastMCP
```

Because the requirement has no upper bound, a fresh install now resolves 2.0.0 and the server cannot start:

```
ModuleNotFoundError: No module named 'mcp.server.fastmcp'
```

Resolution, using the unmodified requirement vs. the capped one:

```console
$ uv pip compile <<< 'mcp[cli]>=1.2.0'
mcp==2.0.0

$ uv pip compile <<< 'mcp[cli]>=1.2.0,<2'
mcp==1.29.0
```

### Why CI is still green

This isn't visible in Actions yet — the most recent run predates the 2.0.0 release by roughly two hours, and existing checkouts keep whatever 1.x version they already resolved. It reproduces on anything that resolves dependencies fresh: a new clone following the README, or a packaged install. I hit it via an `.mcpb` bundle, which re-resolves at install time.

## Verification

Fresh venv, installed from the patched `requirements.txt`:

- `mcp==1.29.0` installed, `from mcp.server.fastmcp import FastMCP` succeeds
- Server module loads, 82 tools registered
- Full suite: **93 passed**

## FWIW — migrating to 2.x looks cheap, if you'd rather do that instead

I checked before proposing the cap, in case pinning was the wrong call. Replacing the import with `MCPServer` appears to be sufficient:

```diff
-from mcp.server.fastmcp import FastMCP
+from mcp.server.mcpserver import MCPServer
```

`MCPServer` exposes a `.tool()` decorator with a compatible signature. With that single change against `mcp==2.0.0`:

- 82 tools register
- **93 passed** (+5 subtests)
- A real stdio handshake negotiates `protocolVersion 2025-06-18` — same as the 1.x server — and `tools/list` returns all 82

Two caveats on that, which is why I'm not proposing it here. The tests are mock-based, so they don't exercise `download_upload` / `download_attachment` — the `ImageContent` / `EmbeddedResource` paths the CHANGELOG already flags as host-sensitive — and 2.0.0 adds a `structured_output` parameter to `.tool()`, which suggests result serialisation may have changed. Verifying that needs a real file through a real host.

So this PR is deliberately just the cap: it unblocks installs immediately without pre-empting the decision on adopting 2.x, which is yours to make. Happy to close this if you'd prefer to go straight to the migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented compatibility issues with MCP 2.0 that could stop the application from starting.
  * Updated the MCP dependency range to include security fixes and remain within the supported 1.x versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->