### PR TITLE
fix: bind the OAuth callback server to localhost

### DIFF
--- a/oauth_app.py
+++ b/oauth_app.py
@@ -455,7 +455,7 @@ if __name__ == '__main__':
         is_debug = os.environ.get('FLASK_DEBUG', 'False').lower() == 'true'
 
         logger.info("Running in %s mode", "debug" if is_debug else "production")
-        app.run(host='0.0.0.0', port=port, debug=is_debug, use_reloader=is_debug)
+        app.run(host='127.0.0.1', port=port, debug=is_debug, use_reloader=is_debug)
     except Exception as e:
         logger.error("Fatal error: %s", str(e), exc_info=True)
         sys.exit(1)


### PR DESCRIPTION
## Problem

`oauth_app.py` runs the Flask OAuth helper on `0.0.0.0`:

```python
app.run(host='0.0.0.0', port=port, debug=is_debug, use_reloader=is_debug)
```

That binds to every network interface, so while the login flow is running, anyone on the same network can reach the endpoint that handles the Basecamp OAuth exchange and writes `oauth_tokens.json`. On a shared or public network that is a needless exposure of a credential path.

## Fix

Bind to `127.0.0.1` instead. One-line change.

This should not reduce functionality: `.env.example` already ships `BASECAMP_REDIRECT_URI=http://localhost:8000/auth/callback`, and the README documents the app as a local, one-shot browser login you run on the same machine. 37signals redirects the browser back to `localhost`, which resolves against a loopback bind.

Anyone who genuinely needs to reach it from another host can front it with a reverse proxy, which is the appropriate place for that decision.

## Testing

Existing suite passes (93 tests), though it does not cover `oauth_app.py`'s bind address.

I have **not** re-run the interactive browser OAuth flow against a live Basecamp account since making this change, so that is worth a maintainer check before merge. The change has been carried in my fork since July and Basecamp API access has continued to work there, but token refresh happens through `auth_manager` rather than this Flask app, so that is not direct evidence the callback path still round-trips.

The one case that would break is a setup where the browser completing the flow runs on a *different* machine than the server. That is not the documented workflow, but if you want to support it, an env-var-controlled host (defaulting to `127.0.0.1`) would be an easy adjustment and I am happy to push it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * The app now listens only on the local machine by default when started directly, reducing unintended network exposure.
  * Port, debug mode, and reload behavior remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->