### PR TITLE
fix: add timeouts to all Basecamp HTTP helpers

### DIFF
--- a/basecamp_client.py
+++ b/basecamp_client.py
@@ -178,22 +178,26 @@ class BasecampClient:
     def post(self, endpoint, data=None):
         """Make a POST request to the Basecamp API."""
         url = f"{self.base_url}/{endpoint}"
-        return requests.post(url, auth=self.auth, headers=self.headers, json=data)
+        return requests.post(url, auth=self.auth, headers=self.headers, json=data,
+                             timeout=(10, 300))
 
     def put(self, endpoint, data=None):
         """Make a PUT request to the Basecamp API."""
         url = f"{self.base_url}/{endpoint}"
-        return requests.put(url, auth=self.auth, headers=self.headers, json=data)
+        return requests.put(url, auth=self.auth, headers=self.headers, json=data,
+                            timeout=(10, 300))
 
     def delete(self, endpoint):
         """Make a DELETE request to the Basecamp API."""
         url = f"{self.base_url}/{endpoint}"
-        return requests.delete(url, auth=self.auth, headers=self.headers)
+        return requests.delete(url, auth=self.auth, headers=self.headers,
+                               timeout=(10, 300))
 
     def patch(self, endpoint, data=None):
         """Make a PATCH request to the Basecamp API."""
         url = f"{self.base_url}/{endpoint}"
-        return requests.patch(url, auth=self.auth, headers=self.headers, json=data)
+        return requests.patch(url, auth=self.auth, headers=self.headers, json=data,
+                              timeout=(10, 300))
 
     # Project methods
     def get_projects(self):

--- a/tests/test_http_helper_timeouts.py
+++ b/tests/test_http_helper_timeouts.py
@@ -1,0 +1,45 @@
+"""Regression tests for the Basecamp client's shared request timeout."""
+
+from unittest.mock import patch
+
+import pytest
+
+from basecamp_client import BasecampClient
+
+
+@pytest.fixture
+def client():
+    instance = BasecampClient.__new__(BasecampClient)
+    instance.base_url = "https://3.basecampapi.com/123"
+    instance.auth = object()
+    instance.headers = {"User-Agent": "test-agent"}
+    return instance
+
+
+@pytest.mark.parametrize(
+    ("verb", "method_name", "expected_kwargs"),
+    [
+        ("get", "get", {"params": {"page": 2}}),
+        ("post", "post", {"json": {"name": "New"}}),
+        ("put", "put", {"json": {"name": "Updated"}}),
+        ("delete", "delete", {}),
+        ("patch", "patch", {"json": {"status": "active"}}),
+    ],
+)
+def test_http_helpers_forward_shared_timeout(client, verb, method_name,
+                                             expected_kwargs):
+    with patch(f"basecamp_client.requests.{verb}") as request:
+        if verb == "get":
+            client.get("resource.json", params=expected_kwargs["params"])
+        elif verb == "delete":
+            client.delete("resource.json")
+        else:
+            getattr(client, method_name)("resource.json", expected_kwargs["json"])
+
+    request.assert_called_once_with(
+        "https://3.basecampapi.com/123/resource.json",
+        auth=client.auth,
+        headers=client.headers,
+        timeout=(10, 300),
+        **expected_kwargs,
+    )


### PR DESCRIPTION
## What changed\n\n- Apply the existing `timeout=(10, 300)` contract to POST, PUT, DELETE, and PATCH requests.\n- Add focused regression coverage for GET, POST, PUT, DELETE, and PATCH.\n\n## Why\n\nWithout an explicit timeout, a stalled Basecamp request can occupy a FastMCP worker indefinitely. This completes the timeout coverage already present on GET and download requests.\n\n## Verification\n\n- `pytest -q tests/test_http_helper_timeouts.py`: 5 passed\n- `pytest -q`: 108 passed\n- `git diff --check origin/main...HEAD`: clean\n\nCloses #40

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added consistent connection and response timeouts to POST, PUT, DELETE, and PATCH requests.
  * Helps prevent requests from hanging indefinitely.

* **Tests**
  * Added coverage verifying timeout, authentication, headers, and request-specific parameters across HTTP methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->